### PR TITLE
Add Glance compatibility for config path and Docker labels

### DIFF
--- a/internal/dynacat/main.go
+++ b/internal/dynacat/main.go
@@ -19,6 +19,9 @@ func Main() int {
 		return 1
 	}
 
+	// Resolve config path with fallback to glance.yml for backward compatibility
+	options.configPath = resolveConfigPath(options.configPath)
+
 	switch options.intent {
 	case cliIntentVersionPrint:
 		fmt.Println(buildVersion)
@@ -88,6 +91,28 @@ func Main() int {
 	}
 
 	return 0
+}
+
+// resolveConfigPath falls back to glance.yml if dynacat.yml (the default) doesn't exist,
+// for backward compatibility with legacy Glance configurations
+func resolveConfigPath(primaryPath string) string {
+	// user explicitly sets config
+	if primaryPath != "dynacat.yml" {
+		return primaryPath
+	}
+
+	// checks if dynacat.yml or glance.yml exists
+	if _, err := os.Stat("dynacat.yml"); err == nil {
+		return primaryPath
+	}
+
+	if _, err := os.Stat("glance.yml"); err == nil {
+		log.Println("Warning: Using legacy glance.yml config file. Please rename it to dynacat.yml to avoid deprecation issues.")
+		return "glance.yml"
+	}
+
+	// If neither exists, just return the original path
+	return primaryPath
 }
 
 func serveApp(configPath string) error {

--- a/internal/dynacat/widget-docker-containers.go
+++ b/internal/dynacat/widget-docker-containers.go
@@ -119,16 +119,20 @@ func (l *dockerContainerLabels) getOrDefault(label, def string) string {
 		return def
 	}
 
-	v, ok := (*l)[label]
-	if !ok {
-		return def
+	if v, ok := (*l)[label]; ok && v != "" {
+		return v
 	}
 
-	if v == "" {
-		return def
+	// If the label is a dynacat key and the label is not found,
+	// try to find a glance key for backward compatibility with existing user configs
+	if strings.HasPrefix(label, "dynacat.") {
+		legacy := "glance." + strings.TrimPrefix(label, "dynacat.")
+		if v, ok := (*l)[legacy]; ok && v != "" {
+			return v
+		}
 	}
 
-	return v
+	return def
 }
 
 type dockerContainer struct {


### PR DESCRIPTION
This PR aims to allow Glance configs when migrating from Glance to dynacat. This is done by manually allowing a `glance.yml` path to be accepted if found in the config directory. This also allows Glance Docker labels to be accepted if the dynacat version cannot be found.

I was experiencing the same issues as specified in #11 and had to manually rename my config to get it to work, since I don't think the README explains in the docker compose to rename this file. I was considering forcing a rename from `glance.yml` to `dynacat.yml`, but I think that method is destructive and it's better to accept glance files for now to allow a smoother transition in the future.

Note that dynacat labels and configs are prioritized over Glance ones.

Fixes #11 