### PR TITLE
Fix thumbnails and relative time disappearing on widget update

### DIFF
--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -949,6 +949,7 @@ async function updateWidget(widgetElement) {
             setupMasonries();
             setupLazyImages();
             setupTruncatedElementTitles();
+            setupDynamicRelativeTime();
 
             const newCallbacks = contentReadyCallbacks.splice(callbacksIndexBefore);
             for (const cb of newCallbacks) {
@@ -977,14 +978,18 @@ function updateContentPreservingImages(oldContent, newContent) {
     const imageMap = new Map();
 
     for (const img of oldImages) {
-        if (!imageMap.has(img.src)) {
-            imageMap.set(img.src, img);
+        const list = imageMap.get(img.src);
+        if (list) {
+            list.push(img);
+        } else {
+            imageMap.set(img.src, [img]);
         }
     }
 
     for (const newImg of newImages) {
-        const oldImg = imageMap.get(newImg.src);
-        if (oldImg) {
+        const list = imageMap.get(newImg.src);
+        if (list && list.length > 0) {
+            const oldImg = list.shift();
             for (const attr of newImg.attributes) {
                 if (attr.name !== 'src' && attr.name !== 'class') {
                     oldImg.setAttribute(attr.name, attr.value);


### PR DESCRIPTION
I was having an issue with my media server history widget. Everything was fine upon landing, but on the first widget update, poster images from history items from the same show were disappearing. I was able to determine that only the _oldest_ history item with that thumbnail was preserving it, and that duplicate images were not being applied properly across all items after the update.

Before:
<img width="1127" height="332" alt="Screenshot 2026-03-27 at 8 16 17 AM" src="https://github.com/user-attachments/assets/a78ecab1-29a3-4587-a171-fed34e787224" />
After:
<img width="1086" height="315" alt="Screenshot 2026-03-27 081708" src="https://github.com/user-attachments/assets/70fff158-ecfc-48ed-afca-e3d3a7a6879a" />

I also noticed that the relative time was disappearing after polling (not sure if it was related to my fix?), so I made an additional change, explicitly setting up dynamic relative time in updateWidget.

Final:
<img width="1124" height="282" alt="Screenshot 2026-03-27 084401" src="https://github.com/user-attachments/assets/41ca4e8c-6274-4789-a9f6-2a8c225d208e" />

Happy to make any changes or if the repo owner wants to implement fix in a better way. But I always think it is better to propose a solution when pointing out a problem, if possible.