### PR TITLE
adds 'hide' function to custom api widgets

### DIFF
--- a/internal/dynacat/static/css/widgets.css
+++ b/internal/dynacat/static/css/widgets.css
@@ -19,6 +19,10 @@
 
 @import "forum-posts.css";
 
+.widget[data-widget-hidden="true"] {
+    display: none;
+}
+
 .widget-error-header {
     display: flex;
     align-items: center;

--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -945,12 +945,12 @@ async function updateWidget(widgetElement) {
     const newWidget = await fetchWidgetContent(widgetElement);
 
     if (newWidget) {
-        if (newWidget.dataset.widgetHidden === 'true') {
-            widgetElement.dataset.widgetHidden = 'true';
+        if (newWidget.dataset.widgetHidden === "true") {
+            widgetElement.dataset.widgetHidden = "true";
         } else {
-            delete widgetElement.dataset.widgetHidden;
+            widgetElement.removeAttribute("data-widget-hidden");
         }
-    }
+}
 
     if (newWidget && widgetElement.outerHTML !== newWidget.outerHTML) {
         const oldContent = widgetElement.querySelector('.widget-content');
@@ -1397,10 +1397,10 @@ async function applyContentUpdate() {
                         oldHeader.innerHTML = newHeader.innerHTML;
                     }
 
-                    if (tempWidget.dataset.widgetHidden === 'true') {
-                        realWidget.dataset.widgetHidden = 'true';
+                    if (tempWidget.dataset.widgetHidden === "true") {
+                        realWidget.dataset.widgetHidden = "true";
                     } else {
-                        delete realWidget.dataset.widgetHidden;
+                        realWidget.removeAttribute("data-widget-hidden");
                     }
 
                     anyReplaced = true;

--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -945,8 +945,11 @@ async function updateWidget(widgetElement) {
     const newWidget = await fetchWidgetContent(widgetElement);
 
     if (newWidget) {
-        const isHidden = newWidget.dataset.widgetHidden === 'true';
-        widgetElement.style.display = isHidden ? 'none' : '';
+        if (newWidget.dataset.widgetHidden === 'true') {
+            widgetElement.dataset.widgetHidden = 'true';
+        } else {
+            delete widgetElement.dataset.widgetHidden;
+        }
     }
 
     if (newWidget && widgetElement.outerHTML !== newWidget.outerHTML) {
@@ -1392,6 +1395,12 @@ async function applyContentUpdate() {
                     const newHeader = tempWidget.querySelector('.widget-header');
                     if (oldHeader && newHeader && oldHeader.innerHTML !== newHeader.innerHTML) {
                         oldHeader.innerHTML = newHeader.innerHTML;
+                    }
+
+                    if (tempWidget.dataset.widgetHidden === 'true') {
+                        realWidget.dataset.widgetHidden = 'true';
+                    } else {
+                        delete realWidget.dataset.widgetHidden;
                     }
 
                     anyReplaced = true;

--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -944,6 +944,11 @@ async function updateWidget(widgetElement) {
     const collapsibleContainerStates = getCollapsibleContainerStates(widgetElement);
     const newWidget = await fetchWidgetContent(widgetElement);
 
+    if (newWidget) {
+        const isHidden = newWidget.dataset.widgetHidden === 'true';
+        widgetElement.style.display = isHidden ? 'none' : '';
+    }
+
     if (newWidget && widgetElement.outerHTML !== newWidget.outerHTML) {
         const oldContent = widgetElement.querySelector('.widget-content');
         const newContent = newWidget.querySelector('.widget-content');

--- a/internal/dynacat/templates/widget-base.html
+++ b/internal/dynacat/templates/widget-base.html
@@ -3,6 +3,7 @@
      {{ if and .UpdateInterval (.IsDynamicUpdateEnabled) }}
      data-update-interval="{{ .UpdateInterval.Milliseconds }}"
      {{ end }}
+     {{ if .Hidden }}data-widget-hidden="true"{{ end }}
      {{ block "widget-data-attrs" . }}{{ end }}>
     {{- if not .HideHeader }}
     <div class="widget-header">

--- a/internal/dynacat/widget-custom-api.go
+++ b/internal/dynacat/widget-custom-api.go
@@ -86,13 +86,14 @@ func (widget *customAPIWidget) initialize() error {
 }
 
 func (widget *customAPIWidget) update(ctx context.Context) {
-	compiledHTML, err := fetchAndRenderCustomAPIRequest(
+	compiledHTML, hidden, err := fetchAndRenderCustomAPIRequest(
 		widget.CustomAPIRequest, widget.Subrequests, widget.Options, widget.compiledTemplate,
 	)
 	if !widget.canContinueUpdateAfterHandlingErr(err) {
 		return
 	}
 
+	widget.Hidden = hidden
 	widget.CompiledHTML = compiledHTML
 }
 
@@ -285,12 +286,14 @@ func fetchCustomAPIResponse(ctx context.Context, req *CustomAPIRequest) (*custom
 	}, nil
 }
 
+const customAPIHideWidgetSentinel = "\x00__dynacat_hide_widget__\x00"
+
 func fetchAndRenderCustomAPIRequest(
 	primaryReq *CustomAPIRequest,
 	subReqs map[string]*CustomAPIRequest,
 	options customAPIOptions,
 	tmpl *template.Template,
-) (template.HTML, error) {
+) (template.HTML, bool, error) {
 	var primaryData *customAPIResponseData
 	subData := make(map[string]*customAPIResponseData, len(subReqs))
 	var err error
@@ -345,7 +348,7 @@ func fetchAndRenderCustomAPIRequest(
 	emptyBody := template.HTML("")
 
 	if err != nil {
-		return emptyBody, err
+		return emptyBody, false, err
 	}
 
 	data := customAPITemplateData{
@@ -357,10 +360,16 @@ func fetchAndRenderCustomAPIRequest(
 	var templateBuffer bytes.Buffer
 	err = tmpl.Execute(&templateBuffer, &data)
 	if err != nil {
-		return emptyBody, err
+		return emptyBody, false, err
 	}
 
-	return template.HTML(templateBuffer.String()), nil
+	output := templateBuffer.String()
+	hidden := strings.Contains(output, customAPIHideWidgetSentinel)
+	if hidden {
+		output = strings.ReplaceAll(output, customAPIHideWidgetSentinel, "")
+	}
+
+	return template.HTML(output), hidden, nil
 }
 
 type decoratedGJSONResult struct {
@@ -687,6 +696,9 @@ var customAPITemplateFuncs = func() template.FuncMap {
 			}
 
 			return data
+		},
+		"hide": func() template.HTML {
+			return template.HTML(customAPIHideWidgetSentinel)
 		},
 	}
 

--- a/internal/dynacat/widget-custom-api.go
+++ b/internal/dynacat/widget-custom-api.go
@@ -86,6 +86,7 @@ func (widget *customAPIWidget) initialize() error {
 }
 
 func (widget *customAPIWidget) update(ctx context.Context) {
+	widget.Hidden = false
 	compiledHTML, hidden, err := fetchAndRenderCustomAPIRequest(
 		widget.CustomAPIRequest, widget.Subrequests, widget.Options, widget.compiledTemplate,
 	)

--- a/internal/dynacat/widget-dynawidgets.go
+++ b/internal/dynacat/widget-dynawidgets.go
@@ -106,13 +106,15 @@ func (widget *dynawidgetsWidget) initialize() error {
 }
 
 func (widget *dynawidgetsWidget) update(ctx context.Context) {
-	compiledHTML, err := fetchAndRenderCustomAPIRequest(
+	widget.Hidden = false
+	compiledHTML, hidden, err := fetchAndRenderCustomAPIRequest(
 		widget.CustomAPIRequest, widget.Subrequests, widget.Options, widget.compiledTemplate,
 	)
 	if !widget.canContinueUpdateAfterHandlingErr(err) {
 		return
 	}
 
+	widget.Hidden = hidden
 	widget.CompiledHTML = compiledHTML
 }
 

--- a/internal/dynacat/widget.go
+++ b/internal/dynacat/widget.go
@@ -164,6 +164,7 @@ type widgetBase struct {
 	TitleIcon           customIconField      `yaml:"title-icon"`
 	TitleURL            string               `yaml:"title-url"`
 	HideHeader          bool                 `yaml:"hide-header"`
+	Hidden              bool                 `yaml:"-"`
 	CSSClass            string               `yaml:"css-class"`
 	CustomCacheDuration durationField        `yaml:"cache"`
 	UpdateInterval      *updateIntervalField `yaml:"update-interval"`


### PR DESCRIPTION
can be called using {{ hide }} in template code. it hides the widget from the dashboard on initial page load and during live updates. I'm currently using it to conditionally hide widgets when they have nothing to show.

example:
```
{{ if eq (len $arr) 0 }}
  {{ hide }}
{{ else }}
// happy path...
```

it works by adding a special string to the template output that the server detects after rendering the widget. if found, it strips it out and marks the widget as hidden. a css rule and the polling js both watch for that attribute to show or hide the widget accordingly.

I used Claude Opus 4.6 to help with implementation, so please double-check the code!