### PR TITLE
feat: Add an upcoming events widget using ICal feeds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Panonim/dynacat
 go 1.25.0
 
 require (
+	github.com/arran4/golang-ical v0.3.5
 	github.com/coreos/go-oidc/v3 v3.11.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/mmcdole/gofeed v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
+github.com/arran4/golang-ical v0.3.5 h1:bbz6ld4dC+MmCKiFfOd6SkmIGnhNMBACZ485ULh7p9A=
+github.com/arran4/golang-ical v0.3.5/go.mod h1:OnguFgjN0Hmx8jzpmWcC+AkHio94ujmLHKoaef7xQh8=
 github.com/coreos/go-oidc/v3 v3.11.0 h1:Ia3MxdwpSw702YW0xgfmP1GVCMA9aEFWu12XUZ3/OtI=
 github.com/coreos/go-oidc/v3 v3.11.0/go.mod h1:gE3LgjOgFoHi9a4ce4/tJczr0Ai2/BoDhf0r5lltWI0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -30,6 +32,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e h1:Q6MvJtQK/iRcRtzAscm/zF23XxJlbECiGPyRicsX+Ak=
 github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e/go.mod h1:autxFIvghDt3jPTLoqZ9OZ7s9qTGNAWmYCjVFWPX/zg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -45,6 +49,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 h1:o4JXh1EVt9k/+g42oCprj/FisM4qX9L3sZB3upGN2ZU=
@@ -155,8 +161,9 @@ golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxb
 golang.org/x/tools v0.43.0 h1:12BdW9CeB3Z+J/I/wj34VMl8X+fEXBxVR90JeMX5E7s=
 golang.org/x/tools v0.43.0/go.mod h1:uHkMso649BX2cZK6+RpuIPXS3ho2hZo4FVwfoy1vIk0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/cc/v4 v4.27.1 h1:9W30zRlYrefrDV2JE2O8VDtJ1yPGownxciz5rrbQZis=

--- a/internal/dynacat/templates/upcoming-events.html
+++ b/internal/dynacat/templates/upcoming-events.html
@@ -1,16 +1,25 @@
 {{ template "widget-base.html" . }} {{- define "widget-content" }}
 <ul class="list list-gap-14">
-    {{- range .UpcomingEvents }}
+    {{- range .UpcomingEvents }} {{ $firstItem := index . 0 }}
+
     <li>
         <div
             class="flex gap-10 row-reverse-on-mobile thumbnail-parent margin-bottom-15"
         >
             <div class="grow min-width-0">
-                <p class="text-center size-h2">{{ .EndDate }}</p>
+                <p class="text-center size-h2">
+                    {{ $firstItem.EndDatePrettyPrint }}
+                </p>
                 <ul class="list list-gap-2">
+                    {{- range . }}
                     <li>
-                        <p>{{ .Content }}</p>
+                        {{ if .IsCurrent }}
+                        <p class="color-highlight">Now - {{ .Content }}</p>
+                        {{ else }}
+                        <p>{{ .StartHour }} - {{ .Content }}</p>
+                        {{ end }}
                     </li>
+                    {{- end }}
                 </ul>
             </div>
         </div>

--- a/internal/dynacat/templates/upcoming-events.html
+++ b/internal/dynacat/templates/upcoming-events.html
@@ -2,13 +2,20 @@
 <ul class="list list-gap-14">
     {{- range .UpcomingEvents }}
     <li>
-        <div class="flex gap-10 row-reverse-on-mobile thumbnail-parent">
+        <div
+            class="flex gap-10 row-reverse-on-mobile thumbnail-parent margin-bottom-15"
+        >
             <div class="grow min-width-0">
-                <p>{{ .EndDate }}</p>
-                <p>{{ .Content }}</p>
+                <p class="text-center size-h2">{{ .EndDate }}</p>
+                <ul class="list list-gap-2">
+                    <li>
+                        <p>{{ .Content }}</p>
+                    </li>
+                </ul>
             </div>
         </div>
     </li>
+    <hr />
     {{- end }}
 </ul>
 {{- end }}

--- a/internal/dynacat/templates/upcoming-events.html
+++ b/internal/dynacat/templates/upcoming-events.html
@@ -1,0 +1,14 @@
+{{ template "widget-base.html" . }} {{- define "widget-content" }}
+<ul class="list list-gap-14">
+    {{- range .UpcomingEvents }}
+    <li>
+        <div class="flex gap-10 row-reverse-on-mobile thumbnail-parent">
+            <div class="grow min-width-0">
+                <p>{{ .EndDate }}</p>
+                <p>{{ .Content }}</p>
+            </div>
+        </div>
+    </li>
+    {{- end }}
+</ul>
+{{- end }}

--- a/internal/dynacat/templates/upcoming-events.html
+++ b/internal/dynacat/templates/upcoming-events.html
@@ -14,7 +14,7 @@
                     {{- range . }}
                     <li>
                         {{ if .IsCurrent }}
-                        <p class="color-highlight">Now - {{ .Content }}</p>
+                        <p class="color-positive">Now - {{ .Content }}</p>
                         {{ else }}
                         <p>{{ .StartHour }} - {{ .Content }}</p>
                         {{ end }}

--- a/internal/dynacat/widget-upcoming-events-ical.go
+++ b/internal/dynacat/widget-upcoming-events-ical.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"html/template"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -13,8 +12,11 @@ import (
 )
 
 type upcomingEventIcal struct {
-	EndDate string
-	Content string
+	EndDate            time.Time
+	Content            string
+	EndDatePrettyPrint string
+	IsCurrent          bool
+	StartHour          string
 }
 
 type upcomingEventsIcalList []upcomingEventIcal
@@ -23,7 +25,7 @@ type upcomingEventsIcalWidget struct {
 	widgetBase     `yaml:",inline"`
 	Limit          int    `yaml:"limit"`
 	IcalURL        string `yaml:"icalURL"`
-	UpcomingEvents upcomingEventsIcalList
+	UpcomingEvents []upcomingEventsIcalList
 }
 
 type Node struct {
@@ -53,10 +55,7 @@ func (widget *upcomingEventsIcalWidget) initialize() error {
 }
 
 func prettyPrintDate(date string) (pretty string, err error) {
-	t, err := time.Parse("20060102", date) // TODO group events on the same date
-	if err != nil {
-		return "", err
-	}
+	t, err := parseDate(date)
 
 	day := t.Day()
 
@@ -68,23 +67,52 @@ func prettyPrintDate(date string) (pretty string, err error) {
 	return result, err
 }
 
-func getUpcomingEvents(icalURL string, limit int) (events upcomingEventsIcalList, err error) {
+func parseDate(date string) (t time.Time, err error) {
+	layout := ""
+	switch len(date) {
+	case 8:
+		layout = "20060102"
+	case 15:
+		layout = "20060102T150405"
+	case 29:
+		layout = "2006-01-02 15:04:05 -0700 MST"
+	default:
+		return time.Time{}, fmt.Errorf("unknown date format: %s", date)
+	}
+	t, err = time.Parse(layout, date)
+	return t, err
+}
+
+func getUpcomingEvents(icalURL string, limit int) (events []upcomingEventsIcalList, err error) {
 	cal, err := ics.ParseCalendarFromUrl(icalURL)
 
-	// TODO manage events currently in progress
 	if err != nil {
 		return nil, err
 	}
 
-	endDate := make(map[string]upcomingEventIcal)
+	endDate := make(map[time.Time]upcomingEventsIcalList)
 
 	for _, component := range cal.Components {
-		dateEnd := ""
+		var dateEnd time.Time
+		isCurrent := false
 		content := ""
+		startHour := ""
 		for _, property := range component.UnknownPropertiesIANAProperties() {
-			if property.IANAToken == "DTEND" {
-				const layout = "20060102"
-				t, err := time.Parse(layout, property.Value)
+			switch property.IANAToken {
+			case "DTSTART":
+				t, err := parseDate(property.Value)
+
+				if err != nil {
+					return nil, err
+				}
+				now := time.Now()
+
+				isCurrent = t.Before(now)
+				startHour = t.Format("15:04")
+				break
+			case "DTEND":
+				t, err := parseDate(property.Value)
+
 				if err != nil {
 					return nil, err
 				}
@@ -94,39 +122,71 @@ func getUpcomingEvents(icalURL string, limit int) (events upcomingEventsIcalList
 					break
 				}
 
-				dateEnd = property.Value
-			} // TODO use switch
-			if property.IANAToken == "SUMMARY" {
+				dateEnd = t
+				break
+			case "SUMMARY":
 				content = property.Value
+				break
 			}
 		}
-		if dateEnd != "" && content != "" {
-			endDate[dateEnd] = upcomingEventIcal{
-				EndDate: dateEnd,
-				Content: content,
+		if !dateEnd.IsZero() && content != "" && startHour != "" {
+			var val upcomingEventsIcalList
+			var ok = false
+			if val, ok = endDate[dateEnd]; !ok {
+				val = upcomingEventsIcalList{}
 			}
+			val = append(val, upcomingEventIcal{
+				EndDate:   dateEnd,
+				Content:   content,
+				IsCurrent: isCurrent,
+				StartHour: startHour,
+			})
+			endDate[dateEnd] = val
 		}
 
-	} // TODO time-based not day-based
-	keys := make([]int, 0, len(endDate))
+	}
+	keys := make([]time.Time, 0, len(endDate))
 	for k := range endDate {
-		val, err := strconv.Atoi(k)
-		keys = append(keys, val)
+		keys = append(keys, k)
 		if err != nil {
 			return nil, err
 		}
 	}
-	slices.Sort(keys)
-	returnValue := make(upcomingEventsIcalList, limit)
-	for i := range limit {
-		keyString := strconv.Itoa(keys[i])
-		evt := endDate[keyString]
-		valPP, err := prettyPrintDate(evt.EndDate)
-		if err != nil {
-			return nil, err
+	slices.SortFunc(keys, func(a, b time.Time) int {
+		return a.Compare(b)
+	})
+
+	returnValue := make([]upcomingEventsIcalList, 0)
+	added := 0
+	keyID := 0
+	for added != limit {
+
+		if keyID >= len(keys) {
+			break
 		}
-		evt.EndDate = valPP
-		returnValue[i] = evt
+
+		evt := endDate[keys[keyID]]
+		if len(evt) < limit-added {
+			added += len(evt)
+
+			valPP, err := prettyPrintDate(evt[0].EndDate.String())
+			if err != nil {
+				return nil, err
+			}
+
+			evt[0].EndDatePrettyPrint = valPP
+			returnValue = append(returnValue, evt)
+		} else {
+			delta := limit - added
+			valPP, err := prettyPrintDate(evt[0].EndDate.String())
+			if err != nil {
+				return nil, err
+			}
+			evt[0].EndDatePrettyPrint = valPP
+			returnValue = append(returnValue, evt[:delta])
+			added += delta
+		}
+		keyID++
 	}
 
 	return returnValue, nil

--- a/internal/dynacat/widget-upcoming-events-ical.go
+++ b/internal/dynacat/widget-upcoming-events-ical.go
@@ -28,11 +28,6 @@ type upcomingEventsIcalWidget struct {
 	UpcomingEvents []upcomingEventsIcalList
 }
 
-type Node struct {
-	Data any
-	Next *Node
-}
-
 func (widget *upcomingEventsIcalWidget) initialize() error {
 	widget.
 		withTitle("Upcoming events").
@@ -54,20 +49,20 @@ func (widget *upcomingEventsIcalWidget) initialize() error {
 	return nil
 }
 
-func prettyPrintDate(date string) (pretty string, err error) {
+func prettyPrintDate(date string) (string, error) {
 	t, err := parseDate(date)
-
-	day := t.Day()
+	if err != nil {
+		return "", err
+	}
 
 	weekday := t.Format("Monday")
 	month := strings.ToLower(t.Format("Jan."))
+	day := t.Day()
 
-	result := fmt.Sprintf("%s %d %s", weekday, day, month)
-
-	return result, err
+	return fmt.Sprintf("%s %d %s", weekday, day, month), nil
 }
 
-func parseDate(date string) (t time.Time, err error) {
+func parseDate(date string) (time.Time, error) {
 	layout := ""
 	switch len(date) {
 	case 8:
@@ -79,117 +74,92 @@ func parseDate(date string) (t time.Time, err error) {
 	default:
 		return time.Time{}, fmt.Errorf("unknown date format: %s", date)
 	}
-	t, err = time.Parse(layout, date)
-	return t, err
+
+	return time.Parse(layout, date)
 }
 
-func getUpcomingEvents(icalURL string, limit int) (events []upcomingEventsIcalList, err error) {
+func getUpcomingEvents(icalURL string, limit int) ([]upcomingEventsIcalList, error) {
 	cal, err := ics.ParseCalendarFromUrl(icalURL)
-
 	if err != nil {
 		return nil, err
 	}
 
-	endDate := make(map[time.Time]upcomingEventsIcalList)
+	eventsByDate := make(map[int]upcomingEventsIcalList)
+	now := time.Now()
 
 	for _, component := range cal.Components {
 		var dateEnd time.Time
-		isCurrent := false
-		content := ""
-		startHour := ""
+		var isCurrent bool
+		var content, startHour string
+
 		for _, property := range component.UnknownPropertiesIANAProperties() {
 			switch property.IANAToken {
 			case "DTSTART":
 				t, err := parseDate(property.Value)
-
 				if err != nil {
 					return nil, err
 				}
-				now := time.Now()
-
 				isCurrent = t.Before(now)
 				startHour = t.Format("15:04")
-				break
+
 			case "DTEND":
 				t, err := parseDate(property.Value)
-
 				if err != nil {
 					return nil, err
 				}
-				now := time.Now()
-
 				if t.Before(now) {
 					break
 				}
-
 				dateEnd = t
-				break
+
 			case "SUMMARY":
 				content = property.Value
-				break
 			}
 		}
+
 		if !dateEnd.IsZero() && content != "" && startHour != "" {
-			var val upcomingEventsIcalList
-			var ok = false
-			if val, ok = endDate[dateEnd]; !ok {
-				val = upcomingEventsIcalList{}
-			}
-			val = append(val, upcomingEventIcal{
+			fmt.Println(dateEnd.String())
+			eventsByDate[dateEnd.YearDay()] = append(eventsByDate[dateEnd.YearDay()], upcomingEventIcal{
 				EndDate:   dateEnd,
 				Content:   content,
 				IsCurrent: isCurrent,
 				StartHour: startHour,
 			})
-			endDate[dateEnd] = val
 		}
-
 	}
-	keys := make([]time.Time, 0, len(endDate))
-	for k := range endDate {
+
+	keys := make([]int, 0, len(eventsByDate))
+	for k := range eventsByDate {
 		keys = append(keys, k)
-		if err != nil {
-			return nil, err
-		}
 	}
-	slices.SortFunc(keys, func(a, b time.Time) int {
-		return a.Compare(b)
-	})
+	slices.Sort(keys)
+	var result []upcomingEventsIcalList
+	totalAdded := 0
 
-	returnValue := make([]upcomingEventsIcalList, 0)
-	added := 0
-	keyID := 0
-	for added != limit {
-
-		if keyID >= len(keys) {
+	for _, key := range keys {
+		if totalAdded >= limit {
 			break
 		}
 
-		evt := endDate[keys[keyID]]
-		if len(evt) < limit-added {
-			added += len(evt)
+		events := eventsByDate[key]
+		remaining := limit - totalAdded
 
-			valPP, err := prettyPrintDate(evt[0].EndDate.String())
-			if err != nil {
-				return nil, err
-			}
-
-			evt[0].EndDatePrettyPrint = valPP
-			returnValue = append(returnValue, evt)
-		} else {
-			delta := limit - added
-			valPP, err := prettyPrintDate(evt[0].EndDate.String())
-			if err != nil {
-				return nil, err
-			}
-			evt[0].EndDatePrettyPrint = valPP
-			returnValue = append(returnValue, evt[:delta])
-			added += delta
+		prettyDate, err := prettyPrintDate(events[0].EndDate.String())
+		if err != nil {
+			return nil, err
 		}
-		keyID++
+		events[0].EndDatePrettyPrint = prettyDate
+
+		if len(events) <= remaining {
+			result = append(result, events)
+			totalAdded += len(events)
+		} else {
+			result = append(result, events[:remaining])
+			totalAdded = limit
+		}
 	}
 
-	return returnValue, nil
+	return result, nil
 }
 
 func (widget *upcomingEventsIcalWidget) update(ctx context.Context) {
@@ -198,7 +168,6 @@ func (widget *upcomingEventsIcalWidget) update(ctx context.Context) {
 		return
 	}
 	widget.UpcomingEvents = evt
-
 }
 
 var upcomingEventsTemplate = mustParseTemplate("upcoming-events.html", "widget-base.html")

--- a/internal/dynacat/widget-upcoming-events-ical.go
+++ b/internal/dynacat/widget-upcoming-events-ical.go
@@ -2,9 +2,11 @@ package dynacat
 
 import (
 	"context"
+	"fmt"
 	"html/template"
 	"slices"
 	"strconv"
+	"strings"
 	"time"
 
 	ics "github.com/arran4/golang-ical"
@@ -48,6 +50,22 @@ func (widget *upcomingEventsIcalWidget) initialize() error {
 	}
 
 	return nil
+}
+
+func prettyPrintDate(date string) (pretty string, err error) {
+	t, err := time.Parse("20060102", date) // TODO group events on the same date
+	if err != nil {
+		return "", err
+	}
+
+	day := t.Day()
+
+	weekday := t.Format("Monday")
+	month := strings.ToLower(t.Format("Jan."))
+
+	result := fmt.Sprintf("%s %d %s", weekday, day, month)
+
+	return result, err
 }
 
 func getUpcomingEvents(icalURL string, limit int) (events upcomingEventsIcalList, err error) {
@@ -102,7 +120,13 @@ func getUpcomingEvents(icalURL string, limit int) (events upcomingEventsIcalList
 	returnValue := make(upcomingEventsIcalList, limit)
 	for i := range limit {
 		keyString := strconv.Itoa(keys[i])
-		returnValue[i] = endDate[keyString]
+		evt := endDate[keyString]
+		valPP, err := prettyPrintDate(evt.EndDate)
+		if err != nil {
+			return nil, err
+		}
+		evt.EndDate = valPP
+		returnValue[i] = evt
 	}
 
 	return returnValue, nil

--- a/internal/dynacat/widget-upcoming-events-ical.go
+++ b/internal/dynacat/widget-upcoming-events-ical.go
@@ -118,7 +118,6 @@ func getUpcomingEvents(icalURL string, limit int) ([]upcomingEventsIcalList, err
 		}
 
 		if !dateEnd.IsZero() && content != "" && startHour != "" {
-			fmt.Println(dateEnd.String())
 			eventsByDate[dateEnd.YearDay()] = append(eventsByDate[dateEnd.YearDay()], upcomingEventIcal{
 				EndDate:   dateEnd,
 				Content:   content,

--- a/internal/dynacat/widget-upcoming-events-ical.go
+++ b/internal/dynacat/widget-upcoming-events-ical.go
@@ -118,7 +118,8 @@ func getUpcomingEvents(icalURL string, limit int) ([]upcomingEventsIcalList, err
 		}
 
 		if !dateEnd.IsZero() && content != "" && startHour != "" {
-			eventsByDate[dateEnd.YearDay()] = append(eventsByDate[dateEnd.YearDay()], upcomingEventIcal{
+			day := int(dateEnd.Unix() / 86400)
+			eventsByDate[day] = append(eventsByDate[day], upcomingEventIcal{
 				EndDate:   dateEnd,
 				Content:   content,
 				IsCurrent: isCurrent,

--- a/internal/dynacat/widget-upcoming-events-ical.go
+++ b/internal/dynacat/widget-upcoming-events-ical.go
@@ -1,0 +1,124 @@
+package dynacat
+
+import (
+	"context"
+	"html/template"
+	"slices"
+	"strconv"
+	"time"
+
+	ics "github.com/arran4/golang-ical"
+)
+
+type upcomingEventIcal struct {
+	EndDate string
+	Content string
+}
+
+type upcomingEventsIcalList []upcomingEventIcal
+
+type upcomingEventsIcalWidget struct {
+	widgetBase     `yaml:",inline"`
+	Limit          int    `yaml:"limit"`
+	IcalURL        string `yaml:"icalURL"`
+	UpcomingEvents upcomingEventsIcalList
+}
+
+type Node struct {
+	Data any
+	Next *Node
+}
+
+func (widget *upcomingEventsIcalWidget) initialize() error {
+	widget.
+		withTitle("Upcoming events").
+		withCacheDuration(30 * time.Minute)
+
+	if widget.UpdateInterval == nil {
+		interval := updateIntervalField(5 * time.Minute)
+		widget.UpdateInterval = &interval
+	}
+
+	if widget.Limit <= 0 {
+		widget.Limit = 5
+	}
+
+	if widget.IcalURL == "" {
+		widget.IcalURL = "https://calendar.google.com/calendar/ical/en.usa%23holiday%40group.v.calendar.google.com/public/basic.ics"
+	}
+
+	return nil
+}
+
+func getUpcomingEvents(icalURL string, limit int) (events upcomingEventsIcalList, err error) {
+	cal, err := ics.ParseCalendarFromUrl(icalURL)
+
+	// TODO manage events currently in progress
+	if err != nil {
+		return nil, err
+	}
+
+	endDate := make(map[string]upcomingEventIcal)
+
+	for _, component := range cal.Components {
+		dateEnd := ""
+		content := ""
+		for _, property := range component.UnknownPropertiesIANAProperties() {
+			if property.IANAToken == "DTEND" {
+				const layout = "20060102"
+				t, err := time.Parse(layout, property.Value)
+				if err != nil {
+					return nil, err
+				}
+				now := time.Now()
+
+				if t.Before(now) {
+					break
+				}
+
+				dateEnd = property.Value
+			} // TODO use switch
+			if property.IANAToken == "SUMMARY" {
+				content = property.Value
+			}
+		}
+		if dateEnd != "" && content != "" {
+			endDate[dateEnd] = upcomingEventIcal{
+				EndDate: dateEnd,
+				Content: content,
+			}
+		}
+
+	} // TODO time-based not day-based
+	keys := make([]int, 0, len(endDate))
+	for k := range endDate {
+		val, err := strconv.Atoi(k)
+		keys = append(keys, val)
+		if err != nil {
+			return nil, err
+		}
+	}
+	slices.Sort(keys)
+	returnValue := make(upcomingEventsIcalList, limit)
+	for i := range limit {
+		keyString := strconv.Itoa(keys[i])
+		returnValue[i] = endDate[keyString]
+	}
+
+	return returnValue, nil
+}
+
+func (widget *upcomingEventsIcalWidget) update(ctx context.Context) {
+	evt, err := getUpcomingEvents(widget.IcalURL, widget.Limit)
+	if !widget.canContinueUpdateAfterHandlingErr(err) {
+		return
+	}
+	widget.UpcomingEvents = evt
+
+}
+
+var upcomingEventsTemplate = mustParseTemplate("upcoming-events.html", "widget-base.html")
+
+func (widget *upcomingEventsIcalWidget) Render() template.HTML {
+	return widget.renderTemplate(widget, upcomingEventsTemplate)
+}

--- a/internal/dynacat/widget.go
+++ b/internal/dynacat/widget.go
@@ -93,6 +93,8 @@ func newWidget(widgetType string) (widget, error) {
 		w = &latestMediaWidget{}
 	case "torrenting":
 		w = &torrentingWidget{}
+	case "upcoming-events-ical":
+		w = &upcomingEventsIcalWidget{}
 	default:
 		return nil, fmt.Errorf("unknown widget type: %s", widgetType)
 	}


### PR DESCRIPTION
Hello,
This PR adds a widget allowing to parse a ICal feed and show upcoming events.

Configuration:
```yaml
- type: upcoming-events-ical
  limit: 10 # The amount of events that will be shown (Default: 5)
  icalURL: https://example.com/[...] # The URL of the ICal stream (Default: https://calendar.google.com/calendar/ical/en.usa%23holiday%40group.v.calendar.google.com/public/basic.ics)
```

Screenshot:
<img width="1822" height="822" alt="image" src="https://github.com/user-attachments/assets/c7556889-ee70-49b0-a567-a9dc5a92b99c" />

The library [arran4/golang-ical](https://github.com/arran4/golang-ical) was used for the ICal parsing