### PR TITLE
Register nested widgets for content refresh

### DIFF
--- a/internal/dynacat/dynacat.go
+++ b/internal/dynacat/dynacat.go
@@ -296,10 +296,22 @@ func newApplication(c *config) (*application, error) {
 			}
 		}
 
-		registerWidget := func(widget widget) {
+		var registerWidget func(widget widget)
+		registerWidget = func(widget widget) {
 			app.widgetByID[widget.GetID()] = widget
 			app.widgetToPage[widget.GetID()] = page
 			widget.setProviders(providers)
+
+			switch v := widget.(type) {
+			case *groupWidget:
+				for i := range v.Widgets {
+					registerWidget(v.Widgets[i])
+				}
+			case *splitColumnWidget:
+				for i := range v.Widgets {
+					registerWidget(v.Widgets[i])
+				}
+			}
 		}
 
 		for i := range page.HeadWidgets {


### PR DESCRIPTION
fixes an issue where lazy-loaded widgets inside `split-column` or `group` containers could show up on the page but fail to load their actual content. The root cause was that nested widgets were not being registered in the same lookup used by the widget content endpoint, so requests for those widgets ended up returning `404`.

### before:
<img width="1192" height="158" alt="image" src="https://github.com/user-attachments/assets/56fac3cc-fbd5-4aae-bb65-a811c8f6b34d" />

### now:
<img width="1176" height="255" alt="image" src="https://github.com/user-attachments/assets/de7786cc-4d04-4c67-92b6-1c7cb9cc73ef" />
