### PR TITLE
Initial implementation of automatic aspect ratio switching

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -458,6 +458,81 @@ theme:
 
 To override the default dark and light themes, use the key names `default-dark` and `default-light`.
 
+## Layout
+
+The `layout` block controls optional layout switching behaviour. Currently it exposes a single option for loading a separate config file when the browser viewport is taller than it is wide (portrait / vertical monitor).
+
+```yaml
+layout:
+  narrow-viewport-config: dynacat-vertical.yml
+```
+
+### Properties
+
+| Name | Type | Required | Default |
+| ---- | ---- | -------- | ------- |
+| narrow-viewport-config | string | no | |
+
+#### `narrow-viewport-config`
+
+Path to a second Dynacat YAML file to use when a visitor's browser viewport is in portrait orientation (`innerWidth < innerHeight`). Relative paths are resolved relative to the primary config file's directory; absolute paths are used as-is.
+
+When set, both config files are loaded and kept in memory. Each browser session is independently routed to the correct layout: Dynacat sets a `dynacat-layout` cookie (values `primary` or `narrow`) and automatically reloads the page whenever the viewport aspect changes. No browser extension or server restart is required to switch between orientations at runtime.
+
+##### Setting up a narrow config
+
+Create a second YAML file (e.g. `dynacat-vertical.yml`) with whatever pages, columns, and widgets suit a vertical screen, then reference it from your primary config:
+
+```yaml
+# dynacat.yml (primary — landscape / wide)
+layout:
+  narrow-viewport-config: dynacat-vertical.yml
+
+pages:
+  - name: Home
+    columns:
+      - size: small
+        widgets: ...
+      - size: full
+        widgets: ...
+```
+
+```yaml
+# dynacat-vertical.yml (narrow / portrait)
+pages:
+  - name: Home
+    columns:
+      - size: full
+        widgets: ...
+```
+
+Use `$include` directives to share widgets, themes, or any other block between the two files and avoid duplication.
+
+##### Docker, `$include`, and narrow-viewport-config
+
+> [!IMPORTANT]
+>
+> In Docker, mount the **whole directory** that holds your primary config, the narrow config file, and **every** file referenced via `$include` (for example `- ./config:/app/config`). The image expects [`dynacat.yml` under `/app/config`](installation.md#docker-compose-manual) by default; includes and `narrow-viewport-config` paths are resolved **inside the container**. If you only bind-mount a single file (e.g. only `dynacat.yml`), sibling YAML files will not exist at `/app/config/` and parsing will fail with “no such file or directory”.
+
+##### Constraints
+
+The following settings **must be identical** in both files. Dynacat will refuse to start if they differ:
+
+- `server.host`, `server.port`, `server.base-url`, `server.https`, `server.proxied`
+- `server.trusted-proxies` — must list the **same** entries as in the primary config (order may differ); otherwise client IP / `X-Forwarded-For` handling can differ per layout profile
+- `server.allowed-embed-hosts` — must match the primary config (order may differ); **only the primary file is used** for `Content-Security-Policy: frame-ancestors`, but mismatched values in the narrow file would be misleading
+- `server.assets-path`, `server.cache-dir`, `server.db-path`
+- `auth.secret-key`
+- `auth.disable-password`, `auth.require-auth`
+- `auth.oidc` — if either file defines `auth.oidc`, both must define it with the **same** `issuer-url`, `client-id`, `client-secret`, `redirect-url`, `scopes`, `username-claim`, `groups-claim`, `allowed-groups`, and `allowed-users` (list order for slices may differ)
+- `auth.users` — the **same set of usernames** must appear in both files (password hashes or plaintext entries should match how you maintain configs; copy the same `users` block or share it via `$include`)
+
+Everything else (`pages`, `theme`, `branding`, `document`) may differ freely.
+
+##### First-load behaviour
+
+On the very first page load the browser may briefly render the primary layout before the JS detects a portrait viewport and reloads to the narrow layout. This is a single reload and only happens once per browser session when the cookie is not yet set or has expired.
+
 ## Pages & Columns
 ![illustration of pages and columns](images/pages-and-columns-illustration.png)
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -53,6 +53,8 @@ services:
     image: panonim/dynacat
     restart: unless-stopped
     volumes:
+      # Mount the full config directory (not only dynacat.yml) so $include files,
+      # narrow-viewport-config peers, and secrets resolve correctly inside the container.
       - ./config:/app/config
       - ./assets:/app/assets
       - /etc/localtime:/etc/localtime:ro

--- a/internal/dynacat/config.go
+++ b/internal/dynacat/config.go
@@ -76,6 +76,10 @@ type config struct {
 	} `yaml:"branding"`
 
 	Pages []page `yaml:"pages"`
+
+	Layout struct {
+		NarrowViewportConfig string `yaml:"narrow-viewport-config"`
+	} `yaml:"layout"`
 }
 
 type oidcConfig struct {
@@ -703,6 +707,213 @@ func (self *orderedYAMLMap[K, V]) Merge(other *orderedYAMLMap[K, V]) *orderedYAM
 	maps.Copy(merged.data, other.data)
 
 	return merged
+}
+
+// extractNarrowConfigPath reads the layout.narrow-viewport-config field from a raw
+// primary config YAML without performing full widget initialisation.
+func extractNarrowConfigPath(rawContents []byte) (string, error) {
+	processed, err := parseConfigVariables(rawContents)
+	if err != nil {
+		return "", fmt.Errorf("parsing config variables: %w", err)
+	}
+	var c struct {
+		Layout struct {
+			NarrowViewportConfig string `yaml:"narrow-viewport-config"`
+		} `yaml:"layout"`
+	}
+	if err := yaml.Unmarshal(processed, &c); err != nil {
+		return "", err
+	}
+	return c.Layout.NarrowViewportConfig, nil
+}
+
+// resolveNarrowConfigPath resolves narrowRelPath relative to the directory of
+// primaryPath. Absolute paths are returned unchanged.
+func resolveNarrowConfigPath(primaryPath, narrowRelPath string) (string, error) {
+	if filepath.IsAbs(narrowRelPath) {
+		return narrowRelPath, nil
+	}
+	absPath, err := filepath.Abs(primaryPath)
+	if err != nil {
+		return "", fmt.Errorf("resolving primary config path: %w", err)
+	}
+	return filepath.Join(filepath.Dir(absPath), narrowRelPath), nil
+}
+
+// dualConfigFilesWatcher watches both the primary config tree and an optional narrow
+// config tree. Whenever any watched file changes it re-parses both trees, extracts
+// the current narrow path from the primary YAML (so mode transitions are handled),
+// and calls onReload with the new content. initialNarrowPath must be a fully
+// resolved absolute path, or empty when no narrow config is currently set.
+func dualConfigFilesWatcher(
+	primaryPath string,
+	lastPrimaryContents []byte,
+	lastPrimaryIncludes map[string]struct{},
+	initialNarrowPath string,
+	lastNarrowContents []byte,
+	lastNarrowIncludes map[string]struct{},
+	onReload func(primaryContents []byte, narrowPath string, narrowContents []byte),
+	onErr func(error),
+) (func() error, error) {
+	primaryAbsPath, err := filepath.Abs(primaryPath)
+	if err != nil {
+		return nil, fmt.Errorf("getting absolute path of primary file: %w", err)
+	}
+	lastPrimaryIncludes[primaryAbsPath] = struct{}{}
+
+	if lastNarrowIncludes == nil {
+		lastNarrowIncludes = make(map[string]struct{})
+	}
+	if initialNarrowPath != "" {
+		lastNarrowIncludes[initialNarrowPath] = struct{}{}
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("creating watcher: %w", err)
+	}
+
+	lastAllIncludes := make(map[string]struct{})
+	maps.Copy(lastAllIncludes, lastPrimaryIncludes)
+	maps.Copy(lastAllIncludes, lastNarrowIncludes)
+
+	lastNarrowPath := initialNarrowPath
+
+	updateWatchedFiles := func(prev, next map[string]struct{}) {
+		for f := range prev {
+			if _, ok := next[f]; !ok {
+				watcher.Remove(f)
+			}
+		}
+		for f := range next {
+			if _, ok := prev[f]; !ok {
+				if err := watcher.Add(f); err != nil {
+					log.Printf(
+						"Could not add file to watcher, changes to this file will not trigger a reload. path: %s, error: %v",
+						f, err,
+					)
+				}
+			}
+		}
+	}
+	updateWatchedFiles(nil, lastAllIncludes)
+
+	mu := sync.Mutex{}
+
+	parseAndCompare := func() {
+		primaryContents, primaryIncludes, err := parseYAMLIncludes(primaryPath)
+		if err != nil {
+			onErr(fmt.Errorf("parsing primary config: %w", err))
+			return
+		}
+		primaryIncludes[primaryAbsPath] = struct{}{}
+
+		newNarrowRelPath, err := extractNarrowConfigPath(primaryContents)
+		if err != nil {
+			onErr(fmt.Errorf("extracting narrow config path: %w", err))
+			return
+		}
+
+		var newNarrowPath string
+		if newNarrowRelPath != "" {
+			newNarrowPath, err = resolveNarrowConfigPath(primaryPath, newNarrowRelPath)
+			if err != nil {
+				onErr(fmt.Errorf("resolving narrow config path: %w", err))
+				return
+			}
+		}
+
+		var narrowContents []byte
+		narrowIncludes := make(map[string]struct{})
+		if newNarrowPath != "" {
+			narrowContents, narrowIncludes, err = parseYAMLIncludes(newNarrowPath)
+			if err != nil {
+				onErr(fmt.Errorf("parsing narrow config: %w", err))
+				return
+			}
+			narrowIncludes[newNarrowPath] = struct{}{}
+		}
+
+		newAllIncludes := make(map[string]struct{})
+		maps.Copy(newAllIncludes, primaryIncludes)
+		maps.Copy(newAllIncludes, narrowIncludes)
+
+		mu.Lock()
+		defer mu.Unlock()
+
+		if !maps.Equal(newAllIncludes, lastAllIncludes) {
+			updateWatchedFiles(lastAllIncludes, newAllIncludes)
+			lastAllIncludes = newAllIncludes
+		}
+
+		primaryChanged := !bytes.Equal(primaryContents, lastPrimaryContents)
+		narrowChanged := newNarrowPath != lastNarrowPath || !bytes.Equal(narrowContents, lastNarrowContents)
+
+		if primaryChanged || narrowChanged {
+			lastPrimaryContents = primaryContents
+			lastNarrowPath = newNarrowPath
+			lastNarrowContents = narrowContents
+			onReload(primaryContents, newNarrowPath, narrowContents)
+		}
+	}
+
+	const debounceDuration = 500 * time.Millisecond
+	var debounceTimer *time.Timer
+	debouncedParseAndCompare := func() {
+		if debounceTimer != nil {
+			debounceTimer.Stop()
+			debounceTimer.Reset(debounceDuration)
+		} else {
+			debounceTimer = time.AfterFunc(debounceDuration, parseAndCompare)
+		}
+	}
+
+	deleteFromLastIncludes := func(filePath string) {
+		mu.Lock()
+		defer mu.Unlock()
+		absPath, _ := filepath.Abs(filePath)
+		delete(lastAllIncludes, absPath)
+	}
+
+	go func() {
+		for {
+			select {
+			case event, isOpen := <-watcher.Events:
+				if !isOpen {
+					return
+				}
+				if event.Has(fsnotify.Write) {
+					debouncedParseAndCompare()
+				} else if event.Has(fsnotify.Rename) {
+					deleteFromLastIncludes(event.Name)
+					for range 10 {
+						if _, err := os.Stat(event.Name); err == nil {
+							break
+						}
+						time.Sleep(200 * time.Millisecond)
+					}
+					debouncedParseAndCompare()
+				} else if event.Has(fsnotify.Remove) {
+					deleteFromLastIncludes(event.Name)
+					debouncedParseAndCompare()
+				}
+			case err, isOpen := <-watcher.Errors:
+				if !isOpen {
+					return
+				}
+				onErr(fmt.Errorf("watcher error: %w", err))
+			}
+		}
+	}()
+
+	onReload(lastPrimaryContents, lastNarrowPath, lastNarrowContents)
+
+	return func() error {
+		if debounceTimer != nil {
+			debounceTimer.Stop()
+		}
+		return watcher.Close()
+	}, nil
 }
 
 func (om *orderedYAMLMap[K, V]) UnmarshalYAML(node *yaml.Node) error {

--- a/internal/dynacat/dynacat.go
+++ b/internal/dynacat/dynacat.go
@@ -69,6 +69,7 @@ type application struct {
 	sseMu                sync.RWMutex
 	sseClients           map[*sseClient]struct{}
 	DynamicUpdateEnabled bool
+	NarrowLayoutEnabled  bool
 
 	imageProxyMu   sync.RWMutex
 	imageProxyURLs map[string]imageProxyInfo
@@ -900,7 +901,8 @@ func (a *application) isRequestHTTPS(r *http.Request) bool {
 	return false
 }
 
-func (a *application) server() (func() error, func() error) {
+// handler builds and returns the http.Handler for this application's routes.
+func (a *application) handler() http.Handler {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("GET /{$}", a.handlePageRequest)
@@ -989,7 +991,6 @@ func (a *application) server() (func() error, func() error) {
 		assetsPath = "/app/assets"
 	}
 
-	absAssetsPath, _ := filepath.Abs(assetsPath)
 	assetsFS := fileServerWithCache(http.Dir(assetsPath), 2*time.Hour)
 	assetsHandler := http.StripPrefix("/assets/", assetsFS)
 	if a.RequiresAuth {
@@ -1004,13 +1005,37 @@ func (a *application) server() (func() error, func() error) {
 		mux.Handle("/assets/{path...}", assetsHandler)
 	}
 
+	return mux
+}
+
+// startAuxiliaryLoops starts the SSE update loop and optional OIDC session sweeper.
+// It returns a cancel function that stops both.
+func (a *application) startAuxiliaryLoops() func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go a.sseUpdateLoop(ctx)
+	if a.oidcSessions != nil {
+		go a.oidcSessions.runSweeper(ctx, 15*time.Minute, OIDC_SESSION_VALID_PERIOD)
+	}
+	return cancel
+}
+
+func (a *application) server() (func() error, func() error) {
+	h := a.handler()
+	cancelLoops := a.startAuxiliaryLoops()
+
+	assetsPath := a.Config.Server.AssetsPath
+	if assetsPath == "" {
+		assetsPath = "/app/assets"
+	}
+	absAssetsPath, _ := filepath.Abs(assetsPath)
+
 	server := http.Server{
 		Addr:    fmt.Sprintf("%s:%d", a.Config.Server.Host, a.Config.Server.Port),
-		Handler: a.securityHeadersMiddleware(mux),
+		Handler: a.securityHeadersMiddleware(h),
 	}
 
 	start := func() error {
-		log.Printf("Starting server on %s:%d (base-url: \"%s\", assets-path: \"%s\")\n",
+		log.Printf("Starting server on %s:%d (base-url: %q, assets-path: %q)\n",
 			a.Config.Server.Host,
 			a.Config.Server.Port,
 			a.Config.Server.BaseURL,
@@ -1024,14 +1049,8 @@ func (a *application) server() (func() error, func() error) {
 		return nil
 	}
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go a.sseUpdateLoop(ctx)
-	if a.oidcSessions != nil {
-		go a.oidcSessions.runSweeper(ctx, 15*time.Minute, OIDC_SESSION_VALID_PERIOD)
-	}
-
 	stop := func() error {
-		cancelCtx()
+		cancelLoops()
 		return server.Close()
 	}
 

--- a/internal/dynacat/layout_switch.go
+++ b/internal/dynacat/layout_switch.go
@@ -1,0 +1,234 @@
+package dynacat
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"path/filepath"
+	"slices"
+	"sync"
+	"time"
+)
+
+const (
+	layoutCookieName     = "dynacat-layout"
+	layoutProfilePrimary = "primary"
+	layoutProfileNarrow  = "narrow"
+)
+
+// layoutDispatcher routes each request to either the primary or narrow application
+// handler based on the dynacat-layout cookie value.
+type layoutDispatcher struct {
+	mu      sync.RWMutex
+	primary http.Handler
+	narrow  http.Handler
+}
+
+func (d *layoutDispatcher) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	d.mu.RLock()
+	primary := d.primary
+	narrow := d.narrow
+	d.mu.RUnlock()
+
+	if narrow != nil {
+		if c, err := r.Cookie(layoutCookieName); err == nil && c.Value == layoutProfileNarrow {
+			narrow.ServeHTTP(w, r)
+			return
+		}
+	}
+	primary.ServeHTTP(w, r)
+}
+
+func (d *layoutDispatcher) update(primary, narrow http.Handler) {
+	d.mu.Lock()
+	d.primary = primary
+	d.narrow = narrow
+	d.mu.Unlock()
+}
+
+// handleSetLayoutProfileRequest handles POST /api/set-layout-profile/{profile}.
+// It sets the dynacat-layout cookie so the dispatcher routes subsequent page loads to
+// the correct application. Auth matches handleThemeChangeRequest when auth is enabled.
+func (a *application) handleSetLayoutProfileRequest(w http.ResponseWriter, r *http.Request) {
+	if a.handleUnauthorizedResponse(w, r, showUnauthorizedJSON) {
+		return
+	}
+
+	profile := r.PathValue("profile")
+	if profile != layoutProfilePrimary && profile != layoutProfileNarrow {
+		http.Error(w, "invalid profile", http.StatusBadRequest)
+		return
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     layoutCookieName,
+		Value:    profile,
+		Path:     a.Config.Server.BaseURL + "/",
+		SameSite: http.SameSiteLaxMode,
+		Expires:  time.Now().Add(2 * 365 * 24 * time.Hour),
+	})
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func sortedStringsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	aa := slices.Clone(a)
+	bb := slices.Clone(b)
+	slices.Sort(aa)
+	slices.Sort(bb)
+	return slices.Equal(aa, bb)
+}
+
+func requireAuthPointersEqual(a, b *bool) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return *a == *b
+}
+
+func validateLayoutPairOIDC(primaryOIDC, narrowOIDC *oidcConfig) error {
+	pNil := primaryOIDC == nil
+	nNil := narrowOIDC == nil
+	if pNil && nNil {
+		return nil
+	}
+	if pNil != nNil {
+		return fmt.Errorf("narrow-viewport-config: auth.oidc must be set in both configs or omitted in both (dual-layout requires identical OIDC settings)")
+	}
+	p, n := primaryOIDC, narrowOIDC
+	if p.IssuerURL != n.IssuerURL {
+		return fmt.Errorf("narrow-viewport-config: auth.oidc.issuer-url must match the primary config")
+	}
+	if p.ClientID != n.ClientID {
+		return fmt.Errorf("narrow-viewport-config: auth.oidc.client-id must match the primary config")
+	}
+	if p.ClientSecret != n.ClientSecret {
+		return fmt.Errorf("narrow-viewport-config: auth.oidc.client-secret must match the primary config")
+	}
+	if p.RedirectURL != n.RedirectURL {
+		return fmt.Errorf("narrow-viewport-config: auth.oidc.redirect-url must match the primary config")
+	}
+	if !sortedStringsEqual(p.Scopes, n.Scopes) {
+		return fmt.Errorf("narrow-viewport-config: auth.oidc.scopes must match the primary config (same entries, order may differ)")
+	}
+	if p.UsernameClaim != n.UsernameClaim {
+		return fmt.Errorf("narrow-viewport-config: auth.oidc.username-claim must match the primary config")
+	}
+	if p.GroupsClaim != n.GroupsClaim {
+		return fmt.Errorf("narrow-viewport-config: auth.oidc.groups-claim must match the primary config")
+	}
+	if !sortedStringsEqual(p.AllowedGroups, n.AllowedGroups) {
+		return fmt.Errorf("narrow-viewport-config: auth.oidc.allowed-groups must match the primary config")
+	}
+	if !sortedStringsEqual(p.AllowedUsers, n.AllowedUsers) {
+		return fmt.Errorf("narrow-viewport-config: auth.oidc.allowed-users must match the primary config")
+	}
+	return nil
+}
+
+func validateLayoutPairAuth(primary, narrow *config) error {
+	if primary.Auth.DisablePassword != narrow.Auth.DisablePassword {
+		return fmt.Errorf("narrow-viewport-config: auth.disable-password must match the primary config")
+	}
+	if !requireAuthPointersEqual(primary.Auth.RequireAuth, narrow.Auth.RequireAuth) {
+		return fmt.Errorf("narrow-viewport-config: auth.require-auth must match the primary config")
+	}
+	if err := validateLayoutPairOIDC(primary.Auth.OIDC, narrow.Auth.OIDC); err != nil {
+		return err
+	}
+	if len(primary.Auth.Users) != len(narrow.Auth.Users) {
+		return fmt.Errorf("narrow-viewport-config: auth.users must define the same usernames as the primary config")
+	}
+	for username := range primary.Auth.Users {
+		if _, ok := narrow.Auth.Users[username]; !ok {
+			return fmt.Errorf("narrow-viewport-config: auth.users is missing username %q (present in primary config)", username)
+		}
+	}
+	return nil
+}
+
+// validateLayoutPairConfigs ensures that server-critical settings are identical
+// between the primary and narrow configs. Pages, widgets, theme, and branding may
+// differ freely between the two files.
+func validateLayoutPairConfigs(primary, narrow *config) error {
+	type check struct {
+		name string
+		a, b any
+	}
+	checks := []check{
+		{"server.host", primary.Server.Host, narrow.Server.Host},
+		{"server.port", primary.Server.Port, narrow.Server.Port},
+		{"server.base-url", primary.Server.BaseURL, narrow.Server.BaseURL},
+		{"server.https", primary.Server.HTTPS, narrow.Server.HTTPS},
+		{"server.proxied", primary.Server.Proxied, narrow.Server.Proxied},
+		{"server.assets-path", primary.Server.AssetsPath, narrow.Server.AssetsPath},
+		{"server.cache-dir", primary.Server.CacheDir, narrow.Server.CacheDir},
+		{"server.db-path", primary.Server.DBPath, narrow.Server.DBPath},
+		{"auth.secret-key", primary.Auth.SecretKey, narrow.Auth.SecretKey},
+	}
+	for _, c := range checks {
+		if fmt.Sprintf("%v", c.a) != fmt.Sprintf("%v", c.b) {
+			return fmt.Errorf("narrow-viewport-config: %s must match the primary config (%v vs %v)", c.name, c.a, c.b)
+		}
+	}
+	if !sortedStringsEqual(primary.Server.TrustedProxies, narrow.Server.TrustedProxies) {
+		return fmt.Errorf("narrow-viewport-config: server.trusted-proxies must match the primary config (same entries, order may differ)")
+	}
+	if !sortedStringsEqual(primary.Server.AllowedEmbedHosts, narrow.Server.AllowedEmbedHosts) {
+		return fmt.Errorf("narrow-viewport-config: server.allowed-embed-hosts must match the primary config (same entries, order may differ; CSP/frame rules use primary only)")
+	}
+	return validateLayoutPairAuth(primary, narrow)
+}
+
+// buildDualServer creates a single http.Server that dispatches between primaryApp and
+// narrowApp based on the dynacat-layout cookie. The layout profile switching endpoint
+// is registered on an outer mux so it is always reachable regardless of active profile.
+func buildDualServer(primaryApp, narrowApp *application) (func() error, func() error) {
+	outerMux := http.NewServeMux()
+	outerMux.HandleFunc(
+		"POST /api/set-layout-profile/{profile}",
+		primaryApp.handleSetLayoutProfileRequest,
+	)
+
+	dispatcher := &layoutDispatcher{}
+	dispatcher.update(primaryApp.handler(), narrowApp.handler())
+	outerMux.Handle("/", dispatcher)
+
+	assetsPath := primaryApp.Config.Server.AssetsPath
+	if assetsPath == "" {
+		assetsPath = "/app/assets"
+	}
+	absAssetsPath, _ := filepath.Abs(assetsPath)
+
+	server := http.Server{
+		Addr:    fmt.Sprintf("%s:%d", primaryApp.Config.Server.Host, primaryApp.Config.Server.Port),
+		Handler: primaryApp.securityHeadersMiddleware(outerMux),
+	}
+
+	cancelPrimary := primaryApp.startAuxiliaryLoops()
+	cancelNarrow := narrowApp.startAuxiliaryLoops()
+
+	start := func() error {
+		log.Printf(
+			"Starting dual-layout server on %s:%d (base-url: %q, assets-path: %q)\n",
+			primaryApp.Config.Server.Host, primaryApp.Config.Server.Port,
+			primaryApp.Config.Server.BaseURL, absAssetsPath,
+		)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	}
+
+	stop := func() error {
+		cancelPrimary()
+		cancelNarrow()
+		return server.Close()
+	}
+
+	return start, stop
+}

--- a/internal/dynacat/main.go
+++ b/internal/dynacat/main.go
@@ -42,9 +42,32 @@ func Main() int {
 			return 1
 		}
 
-		if _, err := newConfigFromYAML(contents); err != nil {
+		primaryConfig, err := newConfigFromYAML(contents)
+		if err != nil {
 			fmt.Printf("Config file is invalid: %v\n", err)
 			return 1
+		}
+
+		if narrowRelPath := primaryConfig.Layout.NarrowViewportConfig; narrowRelPath != "" {
+			narrowPath, err := resolveNarrowConfigPath(options.configPath, narrowRelPath)
+			if err != nil {
+				fmt.Printf("Could not resolve narrow-viewport-config path: %v\n", err)
+				return 1
+			}
+			narrowContents, _, err := parseYAMLIncludes(narrowPath)
+			if err != nil {
+				fmt.Printf("Could not parse narrow config file: %v\n", err)
+				return 1
+			}
+			narrowConfig, err := newConfigFromYAML(narrowContents)
+			if err != nil {
+				fmt.Printf("Narrow config file is invalid: %v\n", err)
+				return 1
+			}
+			if err := validateLayoutPairConfigs(primaryConfig, narrowConfig); err != nil {
+				fmt.Printf("Layout pair validation failed: %v\n", err)
+				return 1
+			}
 		}
 	case cliIntentConfigPrint:
 		contents, _, err := parseYAMLIncludes(options.configPath)
@@ -116,38 +139,60 @@ func resolveConfigPath(primaryPath string) string {
 }
 
 func serveApp(configPath string) error {
-	// TODO: refactor if this gets any more complex, the current implementation is
-	// difficult to reason about due to all of the callbacks and simultaneous operations,
-	// use a single goroutine and a channel to initiate synchronous changes to the server
 	exitChannel := make(chan struct{})
 	hadValidConfigOnStartup := false
 	var stopServer func() error
 
-	onChange := func(newContents []byte) {
+	// onReload handles both single-layout (narrowPath == "") and dual-layout modes.
+	// It is called by the file watcher whenever either config tree changes.
+	onReload := func(primaryContents []byte, narrowPath string, narrowContents []byte) {
 		if stopServer != nil {
 			log.Println("Config file changed, reloading...")
 		}
 
-		config, err := newConfigFromYAML(newContents)
+		primaryConfig, err := newConfigFromYAML(primaryContents)
 		if err != nil {
 			log.Printf("Config has errors: %v", err)
-
 			if !hadValidConfigOnStartup {
 				close(exitChannel)
 			}
-
 			return
 		}
 
-		app, err := newApplication(config)
+		primaryApp, err := newApplication(primaryConfig)
 		if err != nil {
 			log.Printf("Failed to create application: %v", err)
-
 			if !hadValidConfigOnStartup {
 				close(exitChannel)
 			}
-
 			return
+		}
+
+		var narrowApp *application
+		if narrowPath != "" {
+			narrowConfig, err := newConfigFromYAML(narrowContents)
+			if err != nil {
+				log.Printf("Narrow config has errors: %v", err)
+				if !hadValidConfigOnStartup {
+					close(exitChannel)
+				}
+				return
+			}
+			if err := validateLayoutPairConfigs(primaryConfig, narrowConfig); err != nil {
+				log.Printf("Layout pair config error: %v", err)
+				if !hadValidConfigOnStartup {
+					close(exitChannel)
+				}
+				return
+			}
+			narrowApp, err = newApplication(narrowConfig)
+			if err != nil {
+				log.Printf("Failed to create narrow application: %v", err)
+				if !hadValidConfigOnStartup {
+					close(exitChannel)
+				}
+				return
+			}
 		}
 
 		if !hadValidConfigOnStartup {
@@ -161,10 +206,15 @@ func serveApp(configPath string) error {
 		}
 
 		go func() {
-			var startServer func() error
-			startServer, stopServer = app.server()
-
-			if err := startServer(); err != nil {
+			var startFn func() error
+			if narrowApp != nil {
+				primaryApp.NarrowLayoutEnabled = true
+				narrowApp.NarrowLayoutEnabled = true
+				startFn, stopServer = buildDualServer(primaryApp, narrowApp)
+			} else {
+				startFn, stopServer = primaryApp.server()
+			}
+			if err := startFn(); err != nil {
 				log.Printf("Failed to start server: %v", err)
 			}
 		}()
@@ -174,29 +224,74 @@ func serveApp(configPath string) error {
 		log.Printf("Error watching config files: %v", err)
 	}
 
-	configContents, configIncludes, err := parseYAMLIncludes(configPath)
+	primaryContents, primaryIncludes, err := parseYAMLIncludes(configPath)
 	if err != nil {
 		return fmt.Errorf("parsing config: %w", err)
 	}
 
-	stopWatching, err := configFilesWatcher(configPath, configContents, configIncludes, onChange, onErr)
+	// Extract the narrow config path from the raw primary YAML (before full parse).
+	narrowRelPath, err := extractNarrowConfigPath(primaryContents)
+	if err != nil {
+		return fmt.Errorf("extracting narrow config path: %w", err)
+	}
+
+	var narrowPath string
+	var narrowContents []byte
+	var narrowIncludes map[string]struct{}
+	if narrowRelPath != "" {
+		narrowPath, err = resolveNarrowConfigPath(configPath, narrowRelPath)
+		if err != nil {
+			return fmt.Errorf("resolving narrow config path: %w", err)
+		}
+		narrowContents, narrowIncludes, err = parseYAMLIncludes(narrowPath)
+		if err != nil {
+			return fmt.Errorf("parsing narrow config: %w", err)
+		}
+	}
+
+	// dualConfigFilesWatcher handles both single and dual mode; it will dynamically
+	// switch mode if narrow-viewport-config is added or removed at runtime.
+	stopWatching, err := dualConfigFilesWatcher(
+		configPath, primaryContents, primaryIncludes,
+		narrowPath, narrowContents, narrowIncludes,
+		onReload, onErr,
+	)
 	if err == nil {
 		defer stopWatching()
 	} else {
 		log.Printf("Error starting file watcher, config file changes will require a manual restart. (%v)", err)
 
-		config, err := newConfigFromYAML(configContents)
+		// No watcher — start directly (blocking call, no hot-reload).
+		primaryConfig, err := newConfigFromYAML(primaryContents)
 		if err != nil {
 			return fmt.Errorf("validating config file: %w", err)
 		}
-
-		app, err := newApplication(config)
+		primaryApp, err := newApplication(primaryConfig)
 		if err != nil {
 			return fmt.Errorf("creating application: %w", err)
 		}
 
-		startServer, _ := app.server()
-		if err := startServer(); err != nil {
+		var startFn func() error
+		if narrowPath != "" {
+			narrowConfig, err := newConfigFromYAML(narrowContents)
+			if err != nil {
+				return fmt.Errorf("validating narrow config file: %w", err)
+			}
+			if err := validateLayoutPairConfigs(primaryConfig, narrowConfig); err != nil {
+				return fmt.Errorf("layout pair config: %w", err)
+			}
+			narrowApp, err := newApplication(narrowConfig)
+			if err != nil {
+				return fmt.Errorf("creating narrow application: %w", err)
+			}
+			primaryApp.NarrowLayoutEnabled = true
+			narrowApp.NarrowLayoutEnabled = true
+			startFn, _ = buildDualServer(primaryApp, narrowApp)
+		} else {
+			startFn, _ = primaryApp.server()
+		}
+
+		if err := startFn(); err != nil {
 			return fmt.Errorf("starting server: %w", err)
 		}
 	}

--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -1999,6 +1999,64 @@ function fetchLazyWidgets() {
     });
 }
 
+function setupLayoutProfileSwitching() {
+    if (!pageData.narrowLayoutEnabled) return;
+
+    const COOKIE_NAME = 'dynacat-layout';
+    const PROFILE_NARROW = 'narrow';
+    const PROFILE_PRIMARY = 'primary';
+
+    function readLayoutCookie() {
+        const pattern = new RegExp('(?:^|;)\\s*' + COOKIE_NAME + '=([^;]*)');
+        const match = document.cookie.match(pattern);
+        return match ? decodeURIComponent(match[1]) : PROFILE_PRIMARY;
+    }
+
+    function getDesiredProfile() {
+        return window.innerWidth < window.innerHeight ? PROFILE_NARROW : PROFILE_PRIMARY;
+    }
+
+    async function syncLayoutProfile() {
+        const current = readLayoutCookie();
+        const desired = getDesiredProfile();
+        if (current === desired) return;
+
+        try {
+            const response = await fetch(`${pageData.baseURL}/api/set-layout-profile/${desired}`, {
+                method: 'POST',
+                credentials: 'same-origin',
+            });
+            if (!response.ok) {
+                console.error(
+                    'Failed to switch layout profile:',
+                    response.status,
+                    response.statusText,
+                );
+                return;
+            }
+            window.location.reload();
+        } catch (e) {
+            console.error('Failed to switch layout profile:', e);
+        }
+    }
+
+    // Check immediately on page load
+    syncLayoutProfile();
+
+    // Re-check on resize with debounce
+    let resizeTimer = null;
+    window.addEventListener('resize', () => {
+        clearTimeout(resizeTimer);
+        resizeTimer = setTimeout(syncLayoutProfile, 300);
+    });
+
+    // Re-check on orientation change (allow dimensions to update first)
+    window.addEventListener('orientationchange', () => {
+        setTimeout(syncLayoutProfile, 100);
+    });
+}
+
+setupLayoutProfileSwitching();
 setupPage().then(() => {
     startPolling();
     setupWidgetPolling();

--- a/internal/dynacat/templates/document.html
+++ b/internal/dynacat/templates/document.html
@@ -12,6 +12,7 @@
         baseURL: "{{ .App.Config.Server.BaseURL }}",
         theme: "{{ .Request.Theme.Key }}",
         dynamicUpdateEnabled: {{ if .Page }}{{ and .App.DynamicUpdateEnabled (.Page.DynamicUpdatesEnabled) }}{{ else }}{{ .App.DynamicUpdateEnabled }}{{ end }},
+        narrowLayoutEnabled: {{ .App.NarrowLayoutEnabled }},
     };
     </script>
     <title>{{ block "document-title" . }}{{ end }}</title>


### PR DESCRIPTION
# Dual YAML layouts for narrow viewports

This change lets Dynacat load a **second full configuration file** when the browser viewport is taller than it is wide (`innerWidth < innerHeight`). That suits portrait displays and vertical monitors without squeezing a landscape-oriented dashboard layout. The primary config file (unchanged CLI `-config` behavior) remains the default for landscape/wide viewports.

Switching is **per browser**: a cookie selects which `application` instance serves requests. Config reload watches **both** YAML trees and can move between single-app and dual-app mode if `narrow-viewport-config` is added or removed.

---

## User-facing features

- **Optional root YAML block** `layout.narrow-viewport-config` pointing at another Dynacat YAML file (path relative to the primary config’s directory, or absolute).
- **Automatic layout profile**: client detects aspect ratio on load, debounced resize, and `orientationchange`; when it disagrees with the stored cookie it calls `POST /api/set-layout-profile/{primary|narrow}` and reloads once.
- **`dynacat-layout` cookie** (`primary` | `narrow`), path scoped with `server.base-url`, SameSite=Lax, long-lived—aligned with the existing theme cookie pattern.
- **`config:validate`** validates the narrow file when `narrow-viewport-config` is set, including **pair consistency rules** between primary and narrow configs.
- **Backward compatible**: if `layout` is omitted or `narrow-viewport-config` is empty, behavior matches the previous single-config server path.

---

## Configuration example

```yaml
# dynacat.yml (primary)
layout:
  narrow-viewport-config: dynacat-vertical.yml

pages:
  # … landscape-oriented pages …
```

```yaml
# dynacat-vertical.yml — full config; pages/widgets/layout can differ
pages:
  # … portrait-oriented pages …
```

Shared fragments can use **`$include`**. In Docker, mount the **entire config directory** so included files and the narrow root exist inside the container.

---

## Technical implementation

| Area | Notes |
|------|--------|
| **Routing** | New `layoutDispatcher` delegates to `primary.handler()` or `narrow.handler()` based on `dynacat-layout`. |
| **HTTP server** | `buildDualServer` registers `POST /api/set-layout-profile/{profile}` on an outer mux (always reachable), then `/` → dispatcher. Security headers use the **primary** `application` only. |
| **Application lifecycle** | `application.handler()` builds route mux; `startAuxiliaryLoops()` runs SSE (+ OIDC sweeper when present); **both** apps run background loops in dual mode. Standard single-config path still uses `application.server()`. |
| **Reload / fsnotify** | `dualConfigFilesWatcher` unions watched paths from `parseYAMLIncludes` for primary and current narrow root; re-reads `narrow-viewport-config` from primary on each debounced pass so changing or removing the narrow path updates watches and reload logic. |
| **Bootstrap helpers** | `extractNarrowConfigPath`, `resolveNarrowConfigPath` in `config.go`. |
| **Frontend** | `document.html` exposes `pageData.narrowLayoutEnabled`; `page.js` implements sync + `response.ok` guard before reload. |

---

## Pair validation (primary vs narrow)

Startup and reload reject mismatched pairs with clear errors. In addition to scalar `server` fields and `auth.secret-key`, validation includes:

- **`server.trusted-proxies`** — same multiset of entries (order-independent).
- **`server.allowed-embed-hosts`** — same multiset (order-independent); CSP/frame headers still come **only** from the primary config.
- **`auth.disable-password`**, **`auth.require-auth`** (pointer semantics).
- **`auth.oidc`** — both absent or both present with matching fields; slice fields compared order-independently (`scopes`, `allowed-groups`, `allowed-users`).
- **`auth.users`** — same username keys in both files.

Pages, theme, branding, and document head may differ between files.

---

## API

| Method | Path | Purpose |
|--------|------|---------|
| `POST` | `/api/set-layout-profile/primary` | Set cookie to primary (wide) layout. |
| `POST` | `/api/set-layout-profile/narrow` | Set cookie to narrow layout. |

Behavior matches theme-changing endpoints for **authentication**: when auth is required, unauthenticated requests receive `401` JSON instead of setting the cookie.

---

## Known Issues

- First HTML response may use **primary** layout briefly until client JS syncs cookie and reloads.
- Layout profile is **per browser cookie**, not a global server mode.
- **`config:print`** still prints only the primary tree after includes (narrow file unchanged).