### PR TITLE
Changed namespace in docker run commands to lowercase.

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -25,7 +25,7 @@ To generate a secret key:
 Or with Docker:
 
 ```sh
-docker run --rm Panonim/dynacat secret:make
+docker run --rm panonim/dynacat secret:make
 ```
 
 ### Hashed passwords
@@ -39,7 +39,7 @@ Avoid storing plain passwords in your config by hashing them first:
 Or with Docker:
 
 ```sh
-docker run --rm Panonim/dynacat password:hash mysecretpassword
+docker run --rm panonim/dynacat password:hash mysecretpassword
 ```
 
 Then use `password-hash` instead of `password`:


### PR DESCRIPTION
Since using the uppercase namespace caused the image pull to fail for me, I changed it to lowercase.

> [!NOTE]
> Please open the PR to the `beta` branch, as it significantly reduces the time needed for me to review and merge your request.
