### PR TITLE
Add features for navigation bar

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.go]
+indent_style = tab
+
+[Makefile]
+indent_style = tab
+
+[*.{css,js}]
+indent_style = space
+indent_size = 4
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -299,11 +299,14 @@ You can adjust the various parts of the branding through a top level `branding` 
 branding:
   custom-footer: |
     <p>Powered by <a href="https://github.com/Panonim/dynacat">Dynacat</a></p>
+  hide-logo: true
   logo-url: /assets/logo.png
   favicon-url: /assets/logo.png
   app-name: "My Dashboard"
   app-icon-url: "/assets/app-icon.svg"
   app-background-color: "#151519"
+  show-desktop-navigation-on-hover: true
+  center-desktop-navigation: true
 ```
 
 ### Properties
@@ -311,6 +314,7 @@ branding:
 | Name | Type | Required | Default |
 | ---- | ---- | -------- | ------- |
 | hide-footer | bool | no | false |
+| hide-logo | bool | no | false |
 | custom-footer | string | no |  |
 | logo-text | string | no | G |
 | logo-url | string | no | |
@@ -318,9 +322,14 @@ branding:
 | app-name | string | no | Dynacat |
 | app-icon-url | string | no | Dynacat's default icon |
 | app-background-color | string | no | Dynacat's default background color |
+| show-desktop-navigation-on-hover | boolean | no | false |
+| center-desktop-navigation | boolean | no | false |
 
 #### `hide-footer`
 Hides the footer when set to `true`.
+
+#### `hide-logo`
+Hides the logo in the navigation when set to `true`.
 
 #### `custom-footer`
 Specify custom HTML to use for the footer.
@@ -342,6 +351,12 @@ Specify URL for PWA and browser tab icon (512x512 PNG).
 
 #### `app-background-color`
 Specify background color for PWA. Must be a valid CSS color.
+
+#### `show-desktop-navigation-on-hover`
+When set to `true`, hides the desktop navigation at the top edge of the page until the top edge is hovered or the navigation receives focus. Has no effect on mobile navigation.
+
+#### `center-desktop-navigation`
+When set to `true`, centers desktop navigation links instead of aligning them from the start.
 
 ## Theme
 Theming is done through a top level `theme` property. Values for the colors are in [HSL](https://giggster.com/guide/basics/hue-saturation-lightness/) (hue, saturation, lightness) format. You can use a color picker [like this one](https://hslpicker.com/) to convert colors from other formats to HSL. The values are separated by a space and `%` is not required for any of the numbers.

--- a/internal/dynacat/config.go
+++ b/internal/dynacat/config.go
@@ -30,17 +30,17 @@ const (
 
 type config struct {
 	Server struct {
-		Host           string   `yaml:"host"`
-		Port           uint16   `yaml:"port"`
-		Proxied        bool     `yaml:"proxied"`
-		TrustedProxies []string `yaml:"trusted-proxies"`
-		HTTPS          bool     `yaml:"https"`
-		AssetsPath     string   `yaml:"assets-path"`
-		CacheDir       string   `yaml:"cache-dir"`
-		BaseURL        string   `yaml:"base-url"`
-		DBPath              string   `yaml:"db-path"`
-		AllowedEmbedHosts   []string `yaml:"allowed-embed-hosts"`
-		trustedProxyNets []*net.IPNet `yaml:"-"`
+		Host              string       `yaml:"host"`
+		Port              uint16       `yaml:"port"`
+		Proxied           bool         `yaml:"proxied"`
+		TrustedProxies    []string     `yaml:"trusted-proxies"`
+		HTTPS             bool         `yaml:"https"`
+		AssetsPath        string       `yaml:"assets-path"`
+		CacheDir          string       `yaml:"cache-dir"`
+		BaseURL           string       `yaml:"base-url"`
+		DBPath            string       `yaml:"db-path"`
+		AllowedEmbedHosts []string     `yaml:"allowed-embed-hosts"`
+		trustedProxyNets  []*net.IPNet `yaml:"-"`
 	} `yaml:"server"`
 
 	Auth struct {
@@ -64,15 +64,18 @@ type config struct {
 	} `yaml:"theme"`
 
 	Branding struct {
-		HideFooter         bool          `yaml:"hide-footer"`
-		CustomFooter       template.HTML `yaml:"custom-footer"`
-		LogoText           string        `yaml:"logo-text"`
-		LogoURL            string        `yaml:"logo-url"`
-		FaviconURL         string        `yaml:"favicon-url"`
-		FaviconType        string        `yaml:"-"`
-		AppName            string        `yaml:"app-name"`
-		AppIconURL         string        `yaml:"app-icon-url"`
-		AppBackgroundColor string        `yaml:"app-background-color"`
+		HideFooter                   bool          `yaml:"hide-footer"`
+		HideLogo                     bool          `yaml:"hide-logo"`
+		CustomFooter                 template.HTML `yaml:"custom-footer"`
+		LogoText                     string        `yaml:"logo-text"`
+		LogoURL                      string        `yaml:"logo-url"`
+		FaviconURL                   string        `yaml:"favicon-url"`
+		FaviconType                  string        `yaml:"-"`
+		AppName                      string        `yaml:"app-name"`
+		AppIconURL                   string        `yaml:"app-icon-url"`
+		AppBackgroundColor           string        `yaml:"app-background-color"`
+		ShowDesktopNavigationOnHover bool          `yaml:"show-desktop-navigation-on-hover"`
+		CenterDesktopNavigation      bool          `yaml:"center-desktop-navigation"`
 	} `yaml:"branding"`
 
 	Pages []page `yaml:"pages"`

--- a/internal/dynacat/static/css/site.css
+++ b/internal/dynacat/static/css/site.css
@@ -272,6 +272,33 @@ kbd:active {
     gap: var(--header-items-gap);
 }
 
+.header-container-navigation-hover {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 12;
+    margin-top: 0;
+    padding-top: calc(var(--widget-gap) / 2);
+    transform: translateY(calc(-100% + 22px));
+    opacity: 0;
+    transition: transform .2s .6s, opacity .2s .6s;
+}
+
+.header-container-navigation-hover:hover,
+.header-container-navigation-hover:focus-within {
+    transform: translateY(0);
+    opacity: 1;
+    transition-delay: 0s;
+}
+
+.header-container-navigation-hover.nav-autoshow {
+    transform: translateY(0);
+    opacity: 1;
+    transition: none;
+    transition-delay: 0s;
+}
+
 .logo {
     height: 100%;
     flex-shrink: 0;
@@ -301,6 +328,10 @@ kbd:active {
     min-width: 0;
     height: 100%;
     gap: var(--header-items-gap);
+}
+
+.nav-center {
+    justify-content: center;
 }
 
 .nav .nav-item {

--- a/internal/dynacat/static/css/site.css
+++ b/internal/dynacat/static/css/site.css
@@ -330,8 +330,12 @@ kbd:active {
     gap: var(--header-items-gap);
 }
 
-.nav-center {
-    justify-content: center;
+.nav-center .nav-item:first-child {
+    margin-left: auto;
+}
+
+.nav-center .nav-item:last-child {
+    margin-right: auto;
 }
 
 .nav .nav-item {

--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -1200,8 +1200,17 @@ function initDesktopNavigationAutoshow() {
     const navAutoshowKey = "dynacat-nav-autoshow";
     const navLinks = navContainer.querySelectorAll(".nav-item");
 
-    if (sessionStorage.getItem(navAutoshowKey) === "1") {
-        sessionStorage.removeItem(navAutoshowKey);
+    let shouldAutoshow = false;
+    try {
+        shouldAutoshow = sessionStorage.getItem(navAutoshowKey) === "1";
+        if (shouldAutoshow) {
+            sessionStorage.removeItem(navAutoshowKey);
+        }
+    } catch (e) {
+        shouldAutoshow = false;
+    }
+
+    if (shouldAutoshow) {
         navContainer.classList.add("nav-autoshow");
 
         const hide = () => {
@@ -1222,7 +1231,11 @@ function initDesktopNavigationAutoshow() {
     for (let i = 0; i < navLinks.length; i++) {
         const navLink = navLinks[i];
         navLink.addEventListener("click", () => {
-            sessionStorage.setItem(navAutoshowKey, "1");
+            try {
+                sessionStorage.setItem(navAutoshowKey, "1");
+            } catch (e) {
+                return;
+            }
         });
     }
 }

--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -1191,7 +1191,45 @@ function initThemePicker() {
     })
 }
 
+function initDesktopNavigationAutoshow() {
+    const navContainer = document.querySelector(".header-container-navigation-hover");
+    if (!navContainer) {
+        return;
+    }
+
+    const navAutoshowKey = "dynacat-nav-autoshow";
+    const navLinks = navContainer.querySelectorAll(".nav-item");
+
+    if (sessionStorage.getItem(navAutoshowKey) === "1") {
+        sessionStorage.removeItem(navAutoshowKey);
+        navContainer.classList.add("nav-autoshow");
+
+        const hide = () => {
+            navContainer.classList.remove("nav-autoshow");
+            window.removeEventListener("mousemove", hide, { capture: true });
+            window.removeEventListener("scroll", hide, { capture: true });
+            navContainer.removeEventListener("mouseleave", hide, { capture: true });
+        }
+
+        window.addEventListener("mousemove", hide, { passive: true, once: true, capture: true });
+        window.addEventListener("scroll", hide, { passive: true, once: true, capture: true });
+        navContainer.addEventListener("mouseleave", hide, { once: true, capture: true });
+        setTimeout(() => {
+            hide();
+        }, 1800);
+    }
+
+    for (let i = 0; i < navLinks.length; i++) {
+        const navLink = navLinks[i];
+        navLink.addEventListener("click", () => {
+            sessionStorage.setItem(navAutoshowKey, "1");
+        });
+    }
+}
+
 async function setupPage() {
+    initDesktopNavigationAutoshow();
+
     initThemePicker();
 
     const pageElement = document.getElementById("page");

--- a/internal/dynacat/templates.go
+++ b/internal/dynacat/templates.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"math"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -19,7 +20,14 @@ var globalTemplateFunctions = template.FuncMap{
 	"containsStr": func(str, substr string) bool {
 		return strings.Contains(str, substr)
 	},
-	"hasSuffixFold": func(str, suffix string) bool {
+	"hasURLPathSuffixFold": func(str, suffix string) bool {
+		if u, err := url.Parse(str); err == nil {
+			str = u.Path
+		} else {
+			str, _, _ = strings.Cut(str, "?")
+			str, _, _ = strings.Cut(str, "#")
+		}
+
 		return strings.HasSuffix(strings.ToLower(str), strings.ToLower(suffix))
 	},
 	"safeCSS": func(str string) template.CSS {

--- a/internal/dynacat/templates.go
+++ b/internal/dynacat/templates.go
@@ -19,6 +19,9 @@ var globalTemplateFunctions = template.FuncMap{
 	"containsStr": func(str, substr string) bool {
 		return strings.Contains(str, substr)
 	},
+	"hasSuffixFold": func(str, suffix string) bool {
+		return strings.HasSuffix(strings.ToLower(str), strings.ToLower(suffix))
+	},
 	"safeCSS": func(str string) template.CSS {
 		return template.CSS(str)
 	},

--- a/internal/dynacat/templates/page.html
+++ b/internal/dynacat/templates/page.html
@@ -23,7 +23,7 @@
             {{ if not .App.Config.Branding.HideLogo }}
             <div class="logo" aria-hidden="true">
                 {{- if .App.Config.Branding.LogoURL }}
-                {{- if hasSuffixFold .App.Config.Branding.LogoURL ".svg" }}
+                {{- if hasURLPathSuffixFold .App.Config.Branding.LogoURL ".svg" }}
                 <svg width="512" height="512" viewBox="0 0 1 1" class="logo-svg" aria-hidden="true"><image href="{{ .App.Config.Branding.LogoURL }}" width="1" height="1" preserveAspectRatio="xMidYMid meet"></image></svg>
                 {{- else }}
                 <img src="{{ .App.Config.Branding.LogoURL }}" alt="">

--- a/internal/dynacat/templates/page.html
+++ b/internal/dynacat/templates/page.html
@@ -18,11 +18,16 @@
 {{ define "document-body" }}
 <div class="flex flex-column body-content">
     {{ if not .Page.HideDesktopNavigation }}
-    <div class="header-container content-bounds{{ if .Page.DesktopNavigationWidth }} content-bounds-{{ .Page.DesktopNavigationWidth }} {{ end }}">
+    <div class="header-container content-bounds{{ if .Page.DesktopNavigationWidth }} content-bounds-{{ .Page.DesktopNavigationWidth }} {{ end }}{{ if .App.Config.Branding.ShowDesktopNavigationOnHover }} header-container-navigation-hover{{ end }}">
         <div class="header flex padding-inline-widget widget-content-frame">
+            {{ if not .App.Config.Branding.HideLogo }}
             <div class="logo" aria-hidden="true">
                 {{- if .App.Config.Branding.LogoURL }}
+                {{- if hasSuffixFold .App.Config.Branding.LogoURL ".svg" }}
+                <svg width="512" height="512" viewBox="0 0 1 1" class="logo-svg" aria-hidden="true"><image href="{{ .App.Config.Branding.LogoURL }}" width="1" height="1" preserveAspectRatio="xMidYMid meet"></image></svg>
+                {{- else }}
                 <img src="{{ .App.Config.Branding.LogoURL }}" alt="">
+                {{- end }}
                 {{- else if .App.Config.Branding.LogoText }}
                 {{- .App.Config.Branding.LogoText }}
                 {{- else }}
@@ -43,7 +48,8 @@
                 </svg>
                 {{- end }}
             </div>
-            <nav class="nav flex grow hide-scrollbars">
+            {{ end }}
+            <nav class="nav flex grow hide-scrollbars{{ if .App.Config.Branding.CenterDesktopNavigation }} nav-center{{ end }}">
                 {{ template "navigation-links" . }}
             </nav>
             {{ if not .App.Config.Theme.DisablePicker }}


### PR DESCRIPTION
Fix: 

- render user svg from branding correctly (only svg from project was rendered correct before, svg css rules were not applied)

New features:

- Ability to have navbar hidden on desktop, show it on hover (hover height area 22px)
- Ability to center nav-item elements on navbar on desktop 
- Ability to hide logo from navbar

Misc:

- Added hasSuffixFold to internal/dynacat/templates.go for case-insensitive `.svg` suffix checks used by the template.
- Added .editorconfig with project-wide and language-specific formatting defaults for consistent editing behavior.
