### PR TITLE
Make Twitch queries go on batches, fully refactor both existing widgets

### DIFF
--- a/internal/dynacat/twitch-shared.go
+++ b/internal/dynacat/twitch-shared.go
@@ -1,0 +1,73 @@
+package dynacat
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+const twitchGqlEndpoint = "https://gql.twitch.tv/gql"
+const twitchGqlClientId = "kimne78kx3ncx6brgo4mv6wki5h1ko"
+const twitchMaxOperationsPerRequest = 35
+
+type twitchGraphQLOperationRequest struct {
+	OperationName string         `json:"operationName"`
+	Query         string         `json:"query,omitempty"`
+	Variables     any            `json:"variables"`
+	Extensions    map[string]any `json:"extensions,omitempty"`
+}
+
+type twitchGraphQLOperationResponse[T any] struct {
+	Data       T                    `json:"data"`
+	Errors     []twitchGraphQLError `json:"errors"`
+	Extensions struct {
+		OperationName string `json:"operationName"`
+	} `json:"extensions"`
+}
+
+type twitchGraphQLError struct {
+	Message string `json:"message"`
+}
+
+func newTwitchGraphQLQueryRequest(operationName string, variables any, query string) twitchGraphQLOperationRequest {
+	return twitchGraphQLOperationRequest{
+		OperationName: operationName,
+		Query:         query,
+		Variables:     variables,
+	}
+}
+
+func newTwitchGraphQLPersistedQueryRequest(operationName string, variables any, hash string) twitchGraphQLOperationRequest {
+	return twitchGraphQLOperationRequest{
+		OperationName: operationName,
+		Variables:     variables,
+		Extensions: map[string]any{
+			"persistedQuery": map[string]any{
+				"version":    1,
+				"sha256Hash": hash,
+			},
+		},
+	}
+}
+
+func decodeJsonFromTwitchGraphQLRequest[T any](ctx context.Context, operations []twitchGraphQLOperationRequest) ([]twitchGraphQLOperationResponse[T], error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	body, err := json.Marshal(operations)
+	if err != nil {
+		return nil, err
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", twitchGqlEndpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set("Client-ID", twitchGqlClientId)
+	request.Header.Set("Content-Type", "application/json")
+	setBrowserUserAgentHeader(request)
+
+	return decodeJsonFromRequest[[]twitchGraphQLOperationResponse[T]](defaultHTTPClient, request)
+}

--- a/internal/dynacat/widget-shared.go
+++ b/internal/dynacat/widget-shared.go
@@ -6,9 +6,6 @@ import (
 	"time"
 )
 
-const twitchGqlEndpoint = "https://gql.twitch.tv/gql"
-const twitchGqlClientId = "kimne78kx3ncx6brgo4mv6wki5h1ko"
-
 var forumPostsTemplate = mustParseTemplate("forum-posts.html", "widget-base.html")
 
 type forumPost struct {

--- a/internal/dynacat/widget-twitch-channels.go
+++ b/internal/dynacat/widget-twitch-channels.go
@@ -2,11 +2,9 @@ package dynacat
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"html/template"
 	"log/slog"
-	"net/http"
 	"sort"
 	"strings"
 	"time"
@@ -38,7 +36,9 @@ func (widget *twitchChannelsWidget) initialize() error {
 		widget.CollapseAfter = 5
 	}
 
-	if widget.SortBy != "viewers" && widget.SortBy != "live" {
+	switch widget.SortBy {
+	case "viewers", "live":
+	default:
 		widget.SortBy = "viewers"
 	}
 
@@ -46,15 +46,16 @@ func (widget *twitchChannelsWidget) initialize() error {
 }
 
 func (widget *twitchChannelsWidget) update(ctx context.Context) {
-	channels, err := fetchChannelsFromTwitch(widget.ChannelsRequest)
+	channels, err := fetchChannelsFromTwitch(ctx, widget.ChannelsRequest)
 
 	if !widget.canContinueUpdateAfterHandlingErr(err) {
 		return
 	}
 
-	if widget.SortBy == "viewers" {
+	switch widget.SortBy {
+	case "viewers":
 		channels.sortByViewers()
-	} else if widget.SortBy == "live" {
+	case "live":
 		channels.sortByLive()
 	}
 
@@ -115,29 +116,14 @@ func buildTwitchPreviewURL(login string) string {
 	return fmt.Sprintf("https://static-cdn.jtvnw.net/previews-ttv/live_user_%s-440x248.jpg", login)
 }
 
-type twitchOperationResponse struct {
-	Data       json.RawMessage
-	Extensions struct {
-		OperationName string `json:"operationName"`
-	}
-}
-
-type twitchChannelShellOperationResponse struct {
-	UserOrError struct {
-		Type            string `json:"__typename"`
+type twitchChannelStatusOperationResponse struct {
+	User *struct {
 		DisplayName     string `json:"displayName"`
 		ProfileImageUrl string `json:"profileImageURL"`
 		Stream          *struct {
-			ViewersCount int `json:"viewersCount"`
-		}
-	} `json:"userOrError"`
-}
-
-type twitchStreamMetadataOperationResponse struct {
-	UserOrNull *struct {
-		Stream *struct {
-			StartedAt string `json:"createdAt"`
-			Game      *struct {
+			ViewersCount int    `json:"viewersCount"`
+			StartedAt    string `json:"createdAt"`
+			Game         *struct {
 				Slug string `json:"slug"`
 				Name string `json:"name"`
 			} `json:"game"`
@@ -148,114 +134,189 @@ type twitchStreamMetadataOperationResponse struct {
 	} `json:"user"`
 }
 
-const twitchChannelStatusOperationRequestBody = `[
-{"operationName":"ChannelShell","variables":{"login":"%s"},"extensions":{"persistedQuery":{"version":1,"sha256Hash":"580ab410bcd0c1ad194224957ae2241e5d252b2c5173d8e0cce9d32d5bb14efe"}}},
-{"operationName":"StreamMetadata","variables":{"channelLogin":"%s"},"extensions":{"persistedQuery":{"version":1,"sha256Hash":"676ee2f834ede42eb4514cdb432b3134fefc12590080c9a2c9bb44a2a4a63266"}}}
-]`
+const twitchChannelStatusOperationName = "ChannelStatus"
+const twitchChannelStatusOperationQuery = `query ChannelStatus($login: String!) { user(login: $login) { displayName profileImageURL(width: 70) stream { viewersCount createdAt game { name slug } } lastBroadcast { title } } }`
+const twitchChannelsBatchSize = twitchMaxOperationsPerRequest
+const twitchMaxConcurrentBatches = 3
 
-// TODO: rework
-// The operations for multiple channels can all be sent in a single request
-// rather than sending a separate request for each channel. Need to figure out
-// what the limit is for max operations per request and batch operations in
-// multiple requests if number of channels exceeds allowed limit.
+type twitchChannelStatusOperationVariables struct {
+	Login string `json:"login"`
+}
 
-func fetchChannelFromTwitchTask(channel string) (twitchChannel, error) {
+func newTwitchChannelStatusOperationRequest(channel string) twitchGraphQLOperationRequest {
+	return newTwitchGraphQLQueryRequest(
+		twitchChannelStatusOperationName,
+		twitchChannelStatusOperationVariables{Login: channel},
+		twitchChannelStatusOperationQuery,
+	)
+}
+
+func fetchChannelFromTwitchOperation(channel string, response twitchGraphQLOperationResponse[twitchChannelStatusOperationResponse]) (twitchChannel, error) {
 	result := twitchChannel{
 		Login: strings.ToLower(channel),
 	}
 
-	reader := strings.NewReader(fmt.Sprintf(twitchChannelStatusOperationRequestBody, channel, channel))
-	request, _ := http.NewRequest("POST", twitchGqlEndpoint, reader)
-	request.Header.Add("Client-ID", twitchGqlClientId)
-
-	response, err := decodeJsonFromRequest[[]twitchOperationResponse](defaultHTTPClient, request)
-	if err != nil {
-		return result, err
+	switch response.Extensions.OperationName {
+	case twitchChannelStatusOperationName:
+	default:
+		return result, fmt.Errorf("unknown operation name: %s", response.Extensions.OperationName)
 	}
 
-	if len(response) != 2 {
-		return result, fmt.Errorf("expected 2 operation responses, got %d", len(response))
+	if len(response.Errors) > 0 {
+		return result, fmt.Errorf("twitch operation failed: %s", response.Errors[0].Message)
 	}
 
-	var channelShell twitchChannelShellOperationResponse
-	var streamMetadata twitchStreamMetadataOperationResponse
-
-	for i := range response {
-		switch response[i].Extensions.OperationName {
-		case "ChannelShell":
-			if err = json.Unmarshal(response[i].Data, &channelShell); err != nil {
-				return result, fmt.Errorf("unmarshalling channel shell: %w", err)
-			}
-		case "StreamMetadata":
-			if err = json.Unmarshal(response[i].Data, &streamMetadata); err != nil {
-				return result, fmt.Errorf("unmarshalling stream metadata: %w", err)
-			}
-		default:
-			return result, fmt.Errorf("unknown operation name: %s", response[i].Extensions.OperationName)
-		}
-	}
-
-	if channelShell.UserOrError.Type != "User" {
+	if response.Data.User == nil {
 		result.Name = result.Login
+		result.ViewersCount = -1
 		return result, nil
 	}
 
 	result.Exists = true
-	result.Name = channelShell.UserOrError.DisplayName
-	result.AvatarUrl = channelShell.UserOrError.ProfileImageUrl
+	result.Name = response.Data.User.DisplayName
+	result.AvatarUrl = response.Data.User.ProfileImageUrl
 
-	if channelShell.UserOrError.Stream != nil {
+	if response.Data.User.Stream != nil {
 		result.IsLive = true
-		result.ViewersCount = channelShell.UserOrError.Stream.ViewersCount
+		result.ViewersCount = response.Data.User.Stream.ViewersCount
 
-		if streamMetadata.UserOrNull != nil && streamMetadata.UserOrNull.Stream != nil {
-			if streamMetadata.UserOrNull.LastBroadcast != nil {
-				result.StreamTitle = streamMetadata.UserOrNull.LastBroadcast.Title
-			}
+		if response.Data.User.LastBroadcast != nil {
+			result.StreamTitle = response.Data.User.LastBroadcast.Title
+		}
 
-			if streamMetadata.UserOrNull.Stream.Game != nil {
-				result.Category = streamMetadata.UserOrNull.Stream.Game.Name
-				result.CategorySlug = streamMetadata.UserOrNull.Stream.Game.Slug
-			}
-			startedAt, err := time.Parse("2006-01-02T15:04:05Z", streamMetadata.UserOrNull.Stream.StartedAt)
+		if response.Data.User.Stream.Game != nil {
+			result.Category = response.Data.User.Stream.Game.Name
+			result.CategorySlug = response.Data.User.Stream.Game.Slug
+		}
+		startedAt, err := time.Parse(time.RFC3339, response.Data.User.Stream.StartedAt)
 
-			if err == nil {
-				result.LiveSince = startedAt
-			} else {
-				slog.Warn("Failed to parse Twitch stream started at", "error", err, "started_at", streamMetadata.UserOrNull.Stream.StartedAt)
-			}
+		if err == nil {
+			result.LiveSince = startedAt
+		} else {
+			slog.Warn("Failed to parse Twitch stream started at", "error", err, "started_at", response.Data.User.Stream.StartedAt)
 		}
 	} else {
 		// This prevents live channels with 0 viewers from being
-		// incorrectly sorted lower than offline channels
+		// incorrectly sorted lower than offline channels.
 		result.ViewersCount = -1
 	}
 
 	return result, nil
 }
 
-func fetchChannelsFromTwitch(channelLogins []string) (twitchChannelList, error) {
-	result := make(twitchChannelList, 0, len(channelLogins))
+func fetchChannelsFromTwitchBatch(ctx context.Context, channelLogins []string) (twitchChannelList, error) {
+	operations := make([]twitchGraphQLOperationRequest, 0, len(channelLogins))
 
-	job := newJob(fetchChannelFromTwitchTask, channelLogins).withWorkers(10)
-	channels, errs, err := workerPoolDo(job)
+	for i := range channelLogins {
+		operations = append(operations, newTwitchChannelStatusOperationRequest(channelLogins[i]))
+	}
+
+	response, err := decodeJsonFromTwitchGraphQLRequest[twitchChannelStatusOperationResponse](ctx, operations)
+	if err != nil {
+		return nil, err
+	}
+
+	return fetchChannelsFromTwitchOperations(channelLogins, response)
+}
+
+func fetchChannelsFromTwitchOperations(channelLogins []string, response []twitchGraphQLOperationResponse[twitchChannelStatusOperationResponse]) (twitchChannelList, error) {
+	if len(response) != len(channelLogins) {
+		return nil, fmt.Errorf("expected %d operation responses, got %d", len(channelLogins), len(response))
+	}
+
+	channels := make(twitchChannelList, 0, len(channelLogins))
+	var failed int
+
+	for i := range channelLogins {
+		channel, err := fetchChannelFromTwitchOperation(channelLogins[i], response[i])
+		if err != nil {
+			failed++
+			continue
+		}
+		channels = append(channels, channel)
+	}
+
+	if failed > 0 {
+		return channels, fmt.Errorf("%w: failed to fetch %d channels", errPartialContent, failed)
+	}
+
+	return channels, nil
+}
+
+func dedupeTwitchChannelLogins(channelLogins []string) []string {
+	result := make([]string, 0, len(channelLogins))
+	seen := make(map[string]struct{}, len(channelLogins))
+
+	for _, channelLogin := range channelLogins {
+		login := strings.ToLower(strings.TrimSpace(channelLogin))
+		if login == "" {
+			continue
+		}
+
+		if _, ok := seen[login]; ok {
+			continue
+		}
+
+		seen[login] = struct{}{}
+		result = append(result, login)
+	}
+
+	return result
+}
+
+func collectTwitchChannelBatchResults(batches [][]string, batchResults []twitchChannelList, errs []error) (twitchChannelList, int) {
+	result := make(twitchChannelList, 0)
+	var failed int
+
+	for i := range batchResults {
+		result = append(result, batchResults[i]...)
+
+		if errs[i] != nil {
+			failed += len(batches[i]) - len(batchResults[i])
+		}
+	}
+
+	return result, failed
+}
+
+func fetchChannelsFromTwitch(ctx context.Context, channelLogins []string) (twitchChannelList, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Twitch channel logins are case-insensitive, so normalize before deduping requests.
+	channelLogins = dedupeTwitchChannelLogins(channelLogins)
+	result := make(twitchChannelList, 0, len(channelLogins))
+	total := len(channelLogins)
+
+	if len(channelLogins) == 0 {
+		return result, errNoContent
+	}
+
+	batches := make([][]string, 0, (len(channelLogins)+twitchChannelsBatchSize-1)/twitchChannelsBatchSize)
+	for len(channelLogins) > 0 {
+		batchSize := min(len(channelLogins), twitchChannelsBatchSize)
+		batches = append(batches, channelLogins[:batchSize])
+		channelLogins = channelLogins[batchSize:]
+	}
+
+	job := newJob(func(logins []string) (twitchChannelList, error) {
+		return fetchChannelsFromTwitchBatch(ctx, logins)
+	}, batches).withWorkers(min(len(batches), twitchMaxConcurrentBatches))
+	batchResults, errs, err := workerPoolDo(job)
 	if err != nil {
 		return result, err
 	}
 
 	var failed int
-
-	for i := range channels {
+	result, failed = collectTwitchChannelBatchResults(batches, batchResults, errs)
+	for i := range errs {
 		if errs[i] != nil {
-			failed++
-			slog.Error("Failed to fetch Twitch channel", "channel", channelLogins[i], "error", errs[i])
-			continue
+			slog.Error("Failed to fetch Twitch channels", "channels", strings.Join(batches[i], ","), "error", errs[i])
 		}
-
-		result = append(result, channels[i])
 	}
 
-	if failed == len(channelLogins) {
+	if failed == total {
 		return result, errNoContent
 	}
 

--- a/internal/dynacat/widget-twitch-channels_test.go
+++ b/internal/dynacat/widget-twitch-channels_test.go
@@ -1,0 +1,167 @@
+package dynacat
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestFetchChannelFromTwitchOperationsLive(t *testing.T) {
+	channel, err := fetchChannelFromTwitchOperation("Example", twitchOperationResponseFromJSON(t, `{"data":{"user":{"displayName":"Example","profileImageURL":"https://example.com/avatar.png","stream":{"viewersCount":42,"createdAt":"2026-05-16T12:34:56Z","game":{"slug":"science-and-technology","name":"Science & Technology"}},"lastBroadcast":{"title":"Building things"}}},"extensions":{"operationName":"ChannelStatus"}}`))
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if !channel.Exists {
+		t.Fatal("Expected channel to exist")
+	}
+	if !channel.IsLive {
+		t.Fatal("Expected channel to be live")
+	}
+	if channel.Login != "example" {
+		t.Fatalf("Expected login to be normalized, got %q", channel.Login)
+	}
+	if channel.Name != "Example" {
+		t.Fatalf("Expected display name, got %q", channel.Name)
+	}
+	if channel.AvatarUrl != "https://example.com/avatar.png" {
+		t.Fatalf("Expected avatar URL, got %q", channel.AvatarUrl)
+	}
+	if channel.ViewersCount != 42 {
+		t.Fatalf("Expected viewers count 42, got %d", channel.ViewersCount)
+	}
+	if channel.StreamTitle != "Building things" {
+		t.Fatalf("Expected stream title, got %q", channel.StreamTitle)
+	}
+	if channel.Category != "Science & Technology" {
+		t.Fatalf("Expected category, got %q", channel.Category)
+	}
+	if channel.CategorySlug != "science-and-technology" {
+		t.Fatalf("Expected category slug, got %q", channel.CategorySlug)
+	}
+	if !channel.LiveSince.Equal(time.Date(2026, 5, 16, 12, 34, 56, 0, time.UTC)) {
+		t.Fatalf("Expected live since timestamp, got %v", channel.LiveSince)
+	}
+}
+
+func TestFetchChannelFromTwitchOperationsMissing(t *testing.T) {
+	channel, err := fetchChannelFromTwitchOperation("missing_channel", twitchOperationResponseFromJSON(t, `{"data":{"user":null},"extensions":{"operationName":"ChannelStatus"}}`))
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if channel.Exists {
+		t.Fatal("Expected channel not to exist")
+	}
+	if channel.Name != "missing_channel" {
+		t.Fatalf("Expected fallback name, got %q", channel.Name)
+	}
+	if channel.ViewersCount != -1 {
+		t.Fatalf("Expected missing channel viewers count -1, got %d", channel.ViewersCount)
+	}
+}
+
+func TestFetchChannelFromTwitchOperationRejectsMissingOperationName(t *testing.T) {
+	_, err := fetchChannelFromTwitchOperation("example", twitchOperationResponseFromJSON(t, `{"data":{"user":{"displayName":"Example"}}}`))
+	if err == nil {
+		t.Fatal("Expected missing operation name error")
+	}
+}
+
+func TestTwitchChannelListSortByViewersKeepsZeroViewerLiveChannelsAboveOffline(t *testing.T) {
+	channels := twitchChannelList{
+		{Login: "offline-a", ViewersCount: -1},
+		{Login: "live", IsLive: true, ViewersCount: 0},
+		{Login: "offline-b", ViewersCount: -1},
+	}
+
+	channels.sortByViewers()
+
+	if channels[0].Login != "live" {
+		t.Fatalf("Expected live zero-viewer channel first, got %q", channels[0].Login)
+	}
+}
+
+func TestDedupeTwitchChannelLogins(t *testing.T) {
+	logins := dedupeTwitchChannelLogins([]string{" Twitch ", "", "\tMonstercat\n", "twitch"})
+
+	if len(logins) != 2 {
+		t.Fatalf("Expected 2 logins, got %d", len(logins))
+	}
+	if logins[0] != "twitch" || logins[1] != "monstercat" {
+		t.Fatalf("Expected normalized logins, got %#v", logins)
+	}
+}
+
+func TestFetchChannelsFromTwitchOperationsPreservesPartialResults(t *testing.T) {
+	channels, err := fetchChannelsFromTwitchOperations([]string{"first", "broken", "third"}, []twitchGraphQLOperationResponse[twitchChannelStatusOperationResponse]{
+		twitchOperationResponseFromJSON(t, `{"data":{"user":{"displayName":"First"}},"extensions":{"operationName":"ChannelStatus"}}`),
+		twitchOperationResponseFromJSON(t, `{"errors":[{"message":"failed"}],"extensions":{"operationName":"ChannelStatus"}}`),
+		twitchOperationResponseFromJSON(t, `{"data":{"user":{"displayName":"Third"}},"extensions":{"operationName":"ChannelStatus"}}`),
+	})
+	if !errors.Is(err, errPartialContent) {
+		t.Fatalf("Expected partial content error, got %v", err)
+	}
+
+	if len(channels) != 2 {
+		t.Fatalf("Expected 2 channels, got %d", len(channels))
+	}
+	if channels[0].Login != "first" || channels[1].Login != "third" {
+		t.Fatalf("Expected successful channels to be preserved, got %#v", channels)
+	}
+}
+
+func TestFetchChannelsFromTwitchOperationsMapsResponsesByRequestOrder(t *testing.T) {
+	channels, err := fetchChannelsFromTwitchOperations([]string{"first", "second"}, []twitchGraphQLOperationResponse[twitchChannelStatusOperationResponse]{
+		twitchOperationResponseFromJSON(t, `{"data":{"user":{"displayName":"First"}},"extensions":{"operationName":"ChannelStatus"}}`),
+		twitchOperationResponseFromJSON(t, `{"data":{"user":{"displayName":"Second"}},"extensions":{"operationName":"ChannelStatus"}}`),
+	})
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if channels[0].Login != "first" || channels[0].Name != "First" {
+		t.Fatalf("Expected first response to map to first login, got %#v", channels[0])
+	}
+	if channels[1].Login != "second" || channels[1].Name != "Second" {
+		t.Fatalf("Expected second response to map to second login, got %#v", channels[1])
+	}
+}
+
+func TestFetchChannelsFromTwitchOperationsRejectsMismatchedResponses(t *testing.T) {
+	_, err := fetchChannelsFromTwitchOperations([]string{"first", "second"}, []twitchGraphQLOperationResponse[twitchChannelStatusOperationResponse]{
+		twitchOperationResponseFromJSON(t, `{"data":{"user":{"displayName":"First"}},"extensions":{"operationName":"ChannelStatus"}}`),
+	})
+	if err == nil {
+		t.Fatal("Expected response count mismatch error")
+	}
+}
+
+func TestCollectTwitchChannelBatchResultsPreservesPartialBatchResults(t *testing.T) {
+	channels, failed := collectTwitchChannelBatchResults(
+		[][]string{{"one", "two"}, {"three", "four"}},
+		[]twitchChannelList{{{Login: "one"}}, {{Login: "three"}, {Login: "four"}}},
+		[]error{errPartialContent, nil},
+	)
+
+	if failed != 1 {
+		t.Fatalf("Expected 1 failed channel, got %d", failed)
+	}
+	if len(channels) != 3 {
+		t.Fatalf("Expected 3 channels, got %d", len(channels))
+	}
+	if channels[0].Login != "one" || channels[1].Login != "three" || channels[2].Login != "four" {
+		t.Fatalf("Expected successful channels from both batches, got %#v", channels)
+	}
+}
+
+func twitchOperationResponseFromJSON(t *testing.T, data string) twitchGraphQLOperationResponse[twitchChannelStatusOperationResponse] {
+	t.Helper()
+
+	var response twitchGraphQLOperationResponse[twitchChannelStatusOperationResponse]
+	if err := json.Unmarshal([]byte(data), &response); err != nil {
+		t.Fatalf("Failed to unmarshal Twitch operation response: %v", err)
+	}
+	return response
+}

--- a/internal/dynacat/widget-twitch-top-games.go
+++ b/internal/dynacat/widget-twitch-top-games.go
@@ -3,9 +3,7 @@ package dynacat
 import (
 	"context"
 	"errors"
-	"fmt"
 	"html/template"
-	"net/http"
 	"slices"
 	"strings"
 	"time"
@@ -45,7 +43,7 @@ func (widget *twitchGamesWidget) initialize() error {
 }
 
 func (widget *twitchGamesWidget) update(ctx context.Context) {
-	categories, err := fetchTopGamesFromTwitch(widget.Exclude, widget.Limit)
+	categories, err := fetchTopGamesFromTwitch(ctx, widget.Exclude, widget.Limit)
 
 	if !widget.canContinueUpdateAfterHandlingErr(err) {
 		return
@@ -68,36 +66,52 @@ func (widget *twitchGamesWidget) Render() template.HTML {
 }
 
 type twitchCategory struct {
-	Slug         string `json:"slug"`
-	Name         string `json:"name"`
-	AvatarUrl    string `json:"avatarURL"`
-	ViewersCount int    `json:"viewersCount"`
-	Tags         []struct {
-		Name string `json:"tagName"`
-	} `json:"tags"`
-	GameReleaseDate string `json:"originalReleaseDate"`
-	IsNew           bool   `json:"-"`
+	Slug            string              `json:"slug"`
+	Name            string              `json:"name"`
+	AvatarUrl       string              `json:"avatarURL"`
+	ViewersCount    int                 `json:"viewersCount"`
+	Tags            []twitchCategoryTag `json:"tags"`
+	GameReleaseDate string              `json:"originalReleaseDate"`
+	IsNew           bool                `json:"-"`
+}
+
+type twitchCategoryTag struct {
+	Name string `json:"tagName"`
+}
+
+type twitchCategoryEdge struct {
+	Node twitchCategory `json:"node"`
 }
 
 type twitchDirectoriesOperationResponse struct {
-	Data struct {
-		DirectoriesWithTags struct {
-			Edges []struct {
-				Node twitchCategory `json:"node"`
-			} `json:"edges"`
-		} `json:"directoriesWithTags"`
-	} `json:"data"`
+	DirectoriesWithTags struct {
+		Edges []twitchCategoryEdge `json:"edges"`
+	} `json:"directoriesWithTags"`
 }
 
-const twitchDirectoriesOperationRequestBody = `[
-{"operationName": "BrowsePage_AllDirectories","variables": {"limit": %d,"options": {"sort": "VIEWER_COUNT","tags": []}},"extensions": {"persistedQuery": {"version": 1,"sha256Hash": "2f67f71ba89f3c0ed26a141ec00da1defecb2303595f5cda4298169549783d9e"}}}
-]`
+type twitchDirectoriesOperationVariables struct {
+	Limit   int `json:"limit"`
+	Options struct {
+		Sort string   `json:"sort"`
+		Tags []string `json:"tags"`
+	} `json:"options"`
+}
 
-func fetchTopGamesFromTwitch(exclude []string, limit int) ([]twitchCategory, error) {
-	reader := strings.NewReader(fmt.Sprintf(twitchDirectoriesOperationRequestBody, len(exclude)+limit))
-	request, _ := http.NewRequest("POST", twitchGqlEndpoint, reader)
-	request.Header.Add("Client-ID", twitchGqlClientId)
-	response, err := decodeJsonFromRequest[[]twitchDirectoriesOperationResponse](defaultHTTPClient, request)
+const twitchDirectoriesOperationName = "BrowsePage_AllDirectories"
+const twitchDirectoriesOperationHash = "2f67f71ba89f3c0ed26a141ec00da1defecb2303595f5cda4298169549783d9e"
+
+func newTwitchDirectoriesOperationRequest(limit int) twitchGraphQLOperationRequest {
+	variables := twitchDirectoriesOperationVariables{Limit: limit}
+	variables.Options.Sort = "VIEWER_COUNT"
+	variables.Options.Tags = []string{}
+
+	return newTwitchGraphQLPersistedQueryRequest(twitchDirectoriesOperationName, variables, twitchDirectoriesOperationHash)
+}
+
+func fetchTopGamesFromTwitch(ctx context.Context, exclude []string, limit int) ([]twitchCategory, error) {
+	response, err := decodeJsonFromTwitchGraphQLRequest[twitchDirectoriesOperationResponse](ctx, []twitchGraphQLOperationRequest{
+		newTwitchDirectoriesOperationRequest(len(exclude) + limit),
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +120,17 @@ func fetchTopGamesFromTwitch(exclude []string, limit int) ([]twitchCategory, err
 		return nil, errors.New("no categories could be retrieved")
 	}
 
-	edges := (response)[0].Data.DirectoriesWithTags.Edges
+	if len(response[0].Errors) > 0 {
+		return nil, errors.New(response[0].Errors[0].Message)
+	}
+	if response[0].Extensions.OperationName != twitchDirectoriesOperationName {
+		return nil, errors.New("unknown operation name: " + response[0].Extensions.OperationName)
+	}
+
+	return buildTwitchCategories(response[0].Data.DirectoriesWithTags.Edges, exclude, limit), nil
+}
+
+func buildTwitchCategories(edges []twitchCategoryEdge, exclude []string, limit int) []twitchCategory {
 	categories := make([]twitchCategory, 0, len(edges))
 
 	for i := range edges {
@@ -136,5 +160,5 @@ func fetchTopGamesFromTwitch(exclude []string, limit int) ([]twitchCategory, err
 		categories = categories[:limit]
 	}
 
-	return categories, nil
+	return categories
 }

--- a/internal/dynacat/widget-twitch-top-games_test.go
+++ b/internal/dynacat/widget-twitch-top-games_test.go
@@ -1,0 +1,49 @@
+package dynacat
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBuildTwitchCategories(t *testing.T) {
+	categories := buildTwitchCategories([]twitchCategoryEdge{
+		{Node: twitchCategory{
+			Slug:            "excluded",
+			Name:            "Excluded",
+			AvatarUrl:       "https://static-cdn.example/285x380.jpg",
+			GameReleaseDate: time.Now().UTC().Format(time.RFC3339),
+		}},
+		{Node: twitchCategory{
+			Slug:            "included",
+			Name:            "Included",
+			AvatarUrl:       "https://static-cdn.example/285x380.jpg",
+			GameReleaseDate: time.Now().UTC().Format(time.RFC3339),
+			Tags: []twitchCategoryTag{
+				{Name: "One"},
+				{Name: "Two"},
+				{Name: "Three"},
+			},
+		}},
+		{Node: twitchCategory{
+			Slug:      "limited-out",
+			Name:      "Limited Out",
+			AvatarUrl: "https://static-cdn.example/285x380.jpg",
+		}},
+	}, []string{"excluded"}, 1)
+
+	if len(categories) != 1 {
+		t.Fatalf("Expected 1 category, got %d", len(categories))
+	}
+	if categories[0].Slug != "included" {
+		t.Fatalf("Expected included category, got %q", categories[0].Slug)
+	}
+	if categories[0].AvatarUrl != "https://static-cdn.example/144x192.jpg" {
+		t.Fatalf("Expected resized avatar URL, got %q", categories[0].AvatarUrl)
+	}
+	if len(categories[0].Tags) != 2 {
+		t.Fatalf("Expected 2 tags, got %d", len(categories[0].Tags))
+	}
+	if !categories[0].IsNew {
+		t.Fatal("Expected recent category to be marked new")
+	}
+}


### PR DESCRIPTION
## Summary

Improves Twitch widgets by making channel fetching much more efficient and consistent.

## What changed

- Twitch channels now use one compact GraphQL operation per channel instead of multiple persisted operations.
- Channel requests are batched up to 35 operations per request.
- 35 is the live-tested Twitch GQL batch limit: 35 succeeds, 36 returns HTTP 400.
- Large channel lists are split into multiple safe batches automatically.
- Twitch channels and top games now share the same request path, headers, context handling, and JSON decoding.
- Top games keeps its persisted query, but now uses the shared Twitch request helper.

## Impact

- Fewer Twitch requests for channel widgets.
- Lower operation count per channel.
- Better behavior for large channel lists.
- More consistent real-world Twitch request behavior across both Twitch widgets.

## Behavior

If Twitch returns an error for one channel inside a batch, the widget now keeps the other successfully fetched channels and returns partial content instead of dropping the entire batch.