### PR TITLE
Get back LOG_LEVEL config

### DIFF
--- a/internal/dynacat/auth.go
+++ b/internal/dynacat/auth.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	mathrand "math/rand/v2"
 	"net/http"
 	"strconv"
@@ -202,10 +202,7 @@ func (a *application) handleAuthenticationAttempt(w http.ResponseWriter, r *http
 	}
 
 	logAuthFailure := func() {
-		log.Printf(
-			"Failed login attempt for user '%s' from %s",
-			creds.Username, ip,
-		)
+		slog.Warn("Failed login attempt", "username", creds.Username, "ip", ip)
 	}
 
 	if len(creds.Username) == 0 || len(creds.Password) == 0 {
@@ -238,7 +235,7 @@ func (a *application) handleAuthenticationAttempt(w http.ResponseWriter, r *http
 
 	token, err := generateSessionToken(creds.Username, a.authSecretKey, time.Now())
 	if err != nil {
-		log.Printf("Could not compute session token during login attempt: %v", err)
+		slog.Error("Could not compute session token during login attempt", "error", err)
 		time.Sleep(waitOnFailure)
 		w.WriteHeader(http.StatusUnauthorized)
 		return
@@ -266,7 +263,7 @@ func (a *application) getAuthenticatedUser(w http.ResponseWriter, r *http.Reques
 						if shouldRegenerate {
 							newToken, err := generateSessionToken(username, a.authSecretKey, time.Now())
 							if err != nil {
-								log.Printf("Could not compute session token during regeneration: %v", err)
+								slog.Error("Could not compute session token during regeneration", "error", err)
 							} else {
 								a.setAuthSessionCookie(w, r, newToken, time.Now().Add(AUTH_TOKEN_VALID_PERIOD))
 							}
@@ -460,7 +457,7 @@ func (a *application) handleLoginPageRequest(w http.ResponseWriter, r *http.Requ
 	var responseBytes bytes.Buffer
 	err := loginPageTemplate.Execute(&responseBytes, data)
 	if err != nil {
-		log.Printf("rendering login page: %v", err)
+		slog.Error("Rendering login page failed", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("internal server error"))
 		return

--- a/internal/dynacat/auth_oidc.go
+++ b/internal/dynacat/auth_oidc.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"net/http"
 	"strings"
 	"time"
@@ -47,7 +47,7 @@ func initOIDCProvider(cfg *oidcConfig) (*gooidc.Provider, *gooidc.IDTokenVerifie
 func (a *application) handleOIDCLogin(w http.ResponseWriter, r *http.Request) {
 	state, err := makeAuthSecretKey(16)
 	if err != nil {
-		log.Printf("OIDC: could not generate state: %v", err)
+		slog.Error("OIDC could not generate state", "error", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
@@ -131,7 +131,7 @@ func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 	ctx := r.Context()
 	oauth2Token, err := a.oauth2Config.Exchange(ctx, code, oauth2.VerifierOption(pkceCookie.Value))
 	if err != nil {
-		log.Printf("OIDC: token exchange failed: %v", err)
+		slog.Error("OIDC token exchange failed", "error", err)
 		http.Redirect(w, r, baseURL+"/login?error=token_exchange", http.StatusSeeOther)
 		return
 	}
@@ -145,7 +145,7 @@ func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 
 	idToken, err := a.oidcVerifier.Verify(ctx, rawIDToken)
 	if err != nil {
-		log.Printf("OIDC: ID token verification failed: %v", err)
+		slog.Error("OIDC ID token verification failed", "error", err)
 		http.Redirect(w, r, baseURL+"/login?error=token_verify", http.StatusSeeOther)
 		return
 	}
@@ -153,7 +153,7 @@ func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 	// Extract claims
 	var claims map[string]interface{}
 	if err := idToken.Claims(&claims); err != nil {
-		log.Printf("OIDC: could not extract claims: %v", err)
+		slog.Error("OIDC could not extract claims", "error", err)
 		http.Redirect(w, r, baseURL+"/login?error=claims", http.StatusSeeOther)
 		return
 	}
@@ -201,7 +201,7 @@ func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 			}
 		}
 		if !allowed {
-			log.Printf("OIDC: user %s not in allowed users/groups", username)
+			slog.Warn("OIDC user not in allowed users/groups", "username", username)
 			http.Redirect(w, r, baseURL+"/login?error=not_allowed", http.StatusSeeOther)
 			return
 		}
@@ -210,7 +210,7 @@ func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 	// Generate session ID and store session
 	sessionID, err := makeAuthSecretKey(32)
 	if err != nil {
-		log.Printf("OIDC: could not generate session ID: %v", err)
+		slog.Error("OIDC could not generate session ID", "error", err)
 		http.Redirect(w, r, baseURL+"/login?error=internal", http.StatusSeeOther)
 		return
 	}
@@ -232,7 +232,7 @@ func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 		HttpOnly: true,
 	})
 
-	log.Printf("OIDC: user %s logged in", username)
+	slog.Info("OIDC user logged in", "username", username)
 	http.Redirect(w, r, baseURL+"/", http.StatusSeeOther)
 }
 
@@ -273,4 +273,3 @@ func extractGroupsClaim(claims map[string]interface{}, claimName string) []strin
 
 	return nil
 }
-

--- a/internal/dynacat/config.go
+++ b/internal/dynacat/config.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"html/template"
 	"iter"
-	"log"
+	"log/slog"
 	"maps"
 	"net"
 	"os"
@@ -412,10 +412,7 @@ func configFilesWatcher(
 		for filePath := range newWatched {
 			if _, ok := previousWatched[filePath]; !ok {
 				if err := watcher.Add(filePath); err != nil {
-					log.Printf(
-						"Could not add file to watcher, changes to this file will not trigger a reload. path: %s, error: %v",
-						filePath, err,
-					)
+					slog.Warn("Could not add file to watcher, changes to this file will not trigger a reload", "path", filePath, "error", err)
 				}
 			}
 		}

--- a/internal/dynacat/dynacat.go
+++ b/internal/dynacat/dynacat.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -592,7 +592,7 @@ func (a *application) handlePageRequest(w http.ResponseWriter, r *http.Request) 
 	var responseBytes bytes.Buffer
 	err := pageTemplate.Execute(&responseBytes, data)
 	if err != nil {
-		log.Printf("rendering page template: %v", err)
+		slog.Error("Rendering page template failed", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("internal server error"))
 		return
@@ -637,7 +637,7 @@ func (a *application) handlePageContentRequest(w http.ResponseWriter, r *http.Re
 	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
 
 	if err != nil {
-		log.Printf("rendering page content template: %v", err)
+		slog.Error("Rendering page content template failed", "error", err)
 		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("internal server error"))
 		return
@@ -810,7 +810,7 @@ func (a *application) handleTodoLoad(w http.ResponseWriter, r *http.Request) {
 
 	tasks, err := a.todoStorage.loadTasks(listID)
 	if err != nil {
-		log.Printf("todo load: %v", err)
+		slog.Error("Todo load failed", "list_id", listID, "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -839,7 +839,7 @@ func (a *application) handleTodoSave(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := a.todoStorage.saveTasks(listID, tasks); err != nil {
-		log.Printf("todo save: %v", err)
+		slog.Error("Todo save failed", "list_id", listID, "error", err)
 		http.Error(w, "internal server error", http.StatusInternalServerError)
 		return
 	}
@@ -1002,12 +1002,7 @@ func (a *application) server() (func() error, func() error) {
 	}
 
 	start := func() error {
-		log.Printf("Starting server on %s:%d (base-url: \"%s\", assets-path: \"%s\")\n",
-			a.Config.Server.Host,
-			a.Config.Server.Port,
-			a.Config.Server.BaseURL,
-			absAssetsPath,
-		)
+		slog.Info("Starting server", "host", a.Config.Server.Host, "port", a.Config.Server.Port, "base_url", a.Config.Server.BaseURL, "assets_path", absAssetsPath)
 
 		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			return err

--- a/internal/dynacat/embed.go
+++ b/internal/dynacat/embed.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"log"
+	"log/slog"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -42,7 +42,7 @@ func readAllFromStaticFS(path string) ([]byte, error) {
 var staticFSHash = func() string {
 	hash, err := computeFSHash(staticFS)
 	if err != nil {
-		log.Printf("Could not compute static assets cache key: %v", err)
+		slog.Warn("Could not compute static assets cache key", "error", err)
 		return strconv.FormatInt(time.Now().Unix(), 10)
 	}
 

--- a/internal/dynacat/logging.go
+++ b/internal/dynacat/logging.go
@@ -1,0 +1,25 @@
+package dynacat
+
+import (
+	"log/slog"
+	"os"
+	"strings"
+)
+
+func configureLogging() {
+	level := parseLogLevel(os.Getenv("LOG_LEVEL"))
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+}
+
+func parseLogLevel(value string) slog.Level {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "DEBUG":
+		return slog.LevelDebug
+	case "WARN":
+		return slog.LevelWarn
+	case "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/dynacat/main.go
+++ b/internal/dynacat/main.go
@@ -3,7 +3,7 @@ package dynacat
 import (
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,6 +14,8 @@ import (
 var buildVersion = "dev"
 
 func Main() int {
+	configureLogging()
+
 	options, err := parseCliOptions()
 	if err != nil {
 		fmt.Println(err)
@@ -115,7 +117,7 @@ func resolveConfigPath(primaryPath string) string {
 
 	glancePath := filepath.Join(filepath.Dir(primaryPath), "glance.yml")
 	if stat, err := os.Stat(glancePath); err == nil && !stat.IsDir() && stat.Size() > 0 {
-		log.Println("Warning: Using legacy glance.yml config file. Please rename it to dynacat.yml to avoid deprecation issues.")
+		slog.Warn("Using legacy glance.yml config file. Please rename it to dynacat.yml to avoid deprecation issues")
 		return glancePath
 	}
 
@@ -132,12 +134,12 @@ func serveApp(configPath string) error {
 
 	onChange := func(newContents []byte) {
 		if stopServer != nil {
-			log.Println("Config file changed, reloading...")
+			slog.Info("Config file changed, reloading")
 		}
 
 		config, err := newConfigFromYAML(newContents)
 		if err != nil {
-			log.Printf("Config has errors: %v", err)
+			slog.Error("Config has errors", "error", err)
 
 			if !hadValidConfigOnStartup {
 				close(exitChannel)
@@ -148,7 +150,7 @@ func serveApp(configPath string) error {
 
 		app, err := newApplication(config)
 		if err != nil {
-			log.Printf("Failed to create application: %v", err)
+			slog.Error("Failed to create application", "error", err)
 
 			if !hadValidConfigOnStartup {
 				close(exitChannel)
@@ -163,7 +165,7 @@ func serveApp(configPath string) error {
 
 		if stopServer != nil {
 			if err := stopServer(); err != nil {
-				log.Printf("Error while trying to stop server: %v", err)
+				slog.Error("Error while trying to stop server", "error", err)
 			}
 		}
 
@@ -172,13 +174,13 @@ func serveApp(configPath string) error {
 			startServer, stopServer = app.server()
 
 			if err := startServer(); err != nil {
-				log.Printf("Failed to start server: %v", err)
+				slog.Error("Failed to start server", "error", err)
 			}
 		}()
 	}
 
 	onErr := func(err error) {
-		log.Printf("Error watching config files: %v", err)
+		slog.Error("Error watching config files", "error", err)
 	}
 
 	configContents, configIncludes, err := parseYAMLIncludes(configPath)
@@ -190,7 +192,7 @@ func serveApp(configPath string) error {
 	if err == nil {
 		defer stopWatching()
 	} else {
-		log.Printf("Error starting file watcher, config file changes will require a manual restart. (%v)", err)
+		slog.Warn("Error starting file watcher, config file changes will require a manual restart", "error", err)
 
 		config, err := newConfigFromYAML(configContents)
 		if err != nil {


### PR DESCRIPTION
This PR adds working structured logging.
I noticed LOG_LEVEL was already documented, but *it did not actually configure backend logging anymore*, so **`LOG_LEVEL=DEBUG` had no real effect**.

What changed

- Added centralized slog logging setup with LOG_LEVEL env.
- Converted remaining backend log.Print* calls to structured slog.

Why JSON logs - JSON logs are easier to parse locally and are better suited for Kubernetes, Grafana, Loki, and similar log pipelines.