### PR TITLE
Make Github prereleases fetch 3.5x faster

### DIFF
--- a/internal/dynacat/widget-releases.go
+++ b/internal/dynacat/widget-releases.go
@@ -235,7 +235,7 @@ func fetchLatestGithubRelease(request *releaseRequest) (*appRelease, error) {
 	if !request.IncludePreleases {
 		requestURL = fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", request.Repository)
 	} else {
-		requestURL = fmt.Sprintf("https://api.github.com/repos/%s/releases", request.Repository)
+		requestURL = fmt.Sprintf("https://api.github.com/repos/%s/releases?per_page=1", request.Repository)
 	}
 
 	httpRequest, err := http.NewRequest("GET", requestURL, nil)


### PR DESCRIPTION
15-repo live benchmark with `include-prereleases: true`

| Case               |                                   Runs |    Avg | Median |
| ------------------ | -------------------------------------: | -----: | -----: |
| Before no `per_page` | `2250ms, 2668ms, 2091ms, 1855ms, 2623ms` | `2297ms` | `2250ms` |
| After `per_page=1`   |      `716ms, 601ms, 607ms, 704ms, 635ms` |  `653ms` |  `635ms` |

Win:
- Average: `1645ms` faster
- Median: `1616ms` faster
- About `3.5x` faster for `include-prereleases`

---

Sad, that there is nothing can be done to improve speed of latest releases fetch, which is used by majority of people.

I thought, that GraphQL endpoint is fast, but for 15 repositories its more efficient to make 15 network REST calls than 1 GraphQL (yes I tried many things). It seems they have more efficient endpoint with caches. Also this endpoint supports eTag/Last-Modified and its good TODO, but this mostly improves things for 2+ query, not the initial one, — and will require to extract shared eTag code from `rss` widget.

I am not sure where is the right place for such insights.