### PR TITLE
Fix keybinds on non-English keyboard layouts and for digits

### DIFF
--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -107,7 +107,7 @@ let keybindState = { pressedKeys: [], chordTimeout: null };
 function normalizedEventKey(event) {
     const key = event.key.toLowerCase();
     if (/^[a-z0-9]$/.test(key)) return key;
-    // Use physical keys so English binds still work on layouts like Russian.
+    // Use physical key codes so existing binds still work on non-English keyboard layouts
     if (/^Key[A-Z]$/.test(event.code)) return event.code.slice(3).toLowerCase();
     if (/^Digit[0-9]$/.test(event.code)) return event.code.slice(5);
     return "";

--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -104,6 +104,15 @@ function updateRelativeTimeForElements(elements)
 
 let keybindState = { pressedKeys: [], chordTimeout: null };
 
+function normalizedEventKey(event) {
+    const key = event.key.toLowerCase();
+    if (/^[a-z0-9]$/.test(key)) return key;
+    // Use physical keys so English binds still work on layouts like Russian.
+    if (/^Key[A-Z]$/.test(event.code)) return event.code.slice(3).toLowerCase();
+    if (/^Digit[0-9]$/.test(event.code)) return event.code.slice(5);
+    return "";
+}
+
 function setupKeybinds() {
     const nav = document.querySelector("nav.nav");
     if (!nav) return;
@@ -147,8 +156,8 @@ function setupKeybinds() {
         if (document.activeElement.isContentEditable) return;
         if (event.ctrlKey || event.metaKey || event.altKey) return;
 
-        const key = event.key.toLowerCase();
-        if (!/^[a-z0-9]$/.test(key)) return;
+        const key = normalizedEventKey(event);
+        if (!key) return;
 
         clearTimeout(keybindState.chordTimeout);
 


### PR DESCRIPTION
Fix keybinds on non-English keyboard layouts and digits.

- Normalize key events with event.code fallback.
- Keeps existing English data-key-bind values working when the active layout emits another character, e.g. Russian `в` from physical `KeyD`.

---

Why is the `d` prefix hardcoded for single-character keybinds?
Would you be open to removing that automatic prefixing and letting users choose the exact keybind in config instead? I can make a follow-up PR for that. 

I want to use direct "1" and "2" page keybinds without prefix and do not feel wtf moment.
I would like to also document that direct single-key binds can conflict with the search autofocus in that PR.

I have this actually working but that has to go through another PR for sure.