### PR TITLE
Add non-blocking image cache queue

### DIFF
--- a/internal/dynacat/dynacat.go
+++ b/internal/dynacat/dynacat.go
@@ -43,6 +43,8 @@ type application struct {
 	Version   string
 	CreatedAt time.Time
 	Config    config
+	ctx       context.Context
+	cancelCtx context.CancelFunc
 
 	parsedManifest []byte
 
@@ -77,13 +79,16 @@ type application struct {
 }
 
 func newApplication(c *config) (*application, error) {
+	ctx, cancelCtx := context.WithCancel(context.Background())
 	app := &application{
-		Version:        buildVersion,
-		CreatedAt:      time.Now(),
-		Config:         *c,
-		slugToPage:     make(map[string]*page),
-		widgetByID:     make(map[uint64]widget),
-		widgetToPage:   make(map[uint64]*page),
+		Version:          buildVersion,
+		CreatedAt:        time.Now(),
+		Config:           *c,
+		ctx:              ctx,
+		cancelCtx:        cancelCtx,
+		slugToPage:       make(map[string]*page),
+		widgetByID:       make(map[uint64]widget),
+		widgetToPage:     make(map[uint64]*page),
 		sseClients:       make(map[*sseClient]struct{}),
 		imageProxyURLs:   make(map[string]imageProxyInfo),
 		todoListIDToPage: make(map[string]*page),
@@ -428,11 +433,10 @@ func (a *application) sseBroadcast(msg string) {
 	}
 }
 
-func (p *page) updateOutdatedWidgets() {
+func (p *page) updateOutdatedWidgets(ctx context.Context) {
 	now := time.Now()
 
 	var wg sync.WaitGroup
-	context := context.Background()
 
 	for w := range p.HeadWidgets {
 		widget := p.HeadWidgets[w]
@@ -444,7 +448,7 @@ func (p *page) updateOutdatedWidgets() {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			widget.update(context)
+			widget.update(ctx)
 		}()
 	}
 
@@ -459,7 +463,7 @@ func (p *page) updateOutdatedWidgets() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				widget.update(context)
+				widget.update(ctx)
 			}()
 		}
 	}
@@ -635,7 +639,7 @@ func (a *application) handlePageContentRequest(w http.ResponseWriter, r *http.Re
 
 		// Determine cache-build status after widgets have had a chance to queue
 		// image fetches to avoid missing the initial "building cache" response.
-		page.updateOutdatedWidgets()
+		page.updateOutdatedWidgets(a.ctx)
 		if a.imageCache != nil {
 			isCacheBuilding = a.imageCache.IsBuildingCache()
 		}
@@ -1025,14 +1029,13 @@ func (a *application) server() (func() error, func() error) {
 		return nil
 	}
 
-	ctx, cancelCtx := context.WithCancel(context.Background())
-	go a.sseUpdateLoop(ctx)
+	go a.sseUpdateLoop(a.ctx)
 	if a.oidcSessions != nil {
-		go a.oidcSessions.runSweeper(ctx, 15*time.Minute, OIDC_SESSION_VALID_PERIOD)
+		go a.oidcSessions.runSweeper(a.ctx, 15*time.Minute, OIDC_SESSION_VALID_PERIOD)
 	}
 
 	stop := func() error {
-		cancelCtx()
+		a.cancelCtx()
 		return server.Close()
 	}
 

--- a/internal/dynacat/image_cache.go
+++ b/internal/dynacat/image_cache.go
@@ -12,19 +12,35 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 )
 
 type imageCache struct {
-	baseURL  string
-	dir      string
-	mu       sync.Mutex
-	inFlight map[string]*cacheEntry
+	baseURL             string
+	dir                 string
+	mu                  sync.Mutex
+	inFlight            map[string]*cacheEntry
+	backgroundDownloads chan struct{}
 }
 
+const maxBackgroundImageDownloads = 1
+
 type cacheEntry struct {
-	done chan struct{}
-	url  string
-	err  error
+	done        chan struct{}
+	ready       chan struct{}
+	readyOnce   sync.Once
+	background  bool
+	tmpPath     string
+	contentType string
+	url         string
+	err         error
+}
+
+type imageCacheLookup struct {
+	parsed    *url.URL
+	hashHex   string
+	cachedURL string
+	cacheable bool
 }
 
 var allowedImageExtensions = []string{
@@ -55,9 +71,10 @@ var contentTypeToExtension = map[string]string{
 
 func newImageCache(baseURL string, dir string) *imageCache {
 	return &imageCache{
-		baseURL:  strings.TrimRight(baseURL, "/"),
-		dir:      dir,
-		inFlight: make(map[string]*cacheEntry),
+		baseURL:             strings.TrimRight(baseURL, "/"),
+		dir:                 dir,
+		inFlight:            make(map[string]*cacheEntry),
+		backgroundDownloads: make(chan struct{}, maxBackgroundImageDownloads),
 	}
 }
 
@@ -66,43 +83,175 @@ func (c *imageCache) CacheURL(ctx context.Context, rawURL string) (string, error
 }
 
 func (c *imageCache) CacheURLWithClient(ctx context.Context, rawURL string, allowInsecure bool) (string, error) {
-	if c == nil || rawURL == "" {
-		return "", nil
+	lookup, err := c.lookup(rawURL)
+	if err != nil || !lookup.cacheable || lookup.cachedURL != "" {
+		return lookup.cachedURL, err
 	}
 
-	parsed, err := url.Parse(rawURL)
-	if err != nil {
-		return "", err
-	}
-
-	if parsed.Scheme != "http" && parsed.Scheme != "https" {
-		return "", nil
-	}
-
-	hashHex := hashString(rawURL)
-	if existing, ok := c.findExistingFile(hashHex, parsed.Path); ok {
-		return c.publicURL(existing), nil
-	}
-
-	c.mu.Lock()
-	if entry, ok := c.inFlight[rawURL]; ok {
-		c.mu.Unlock()
+	key := imageCacheKey(rawURL, allowInsecure)
+	entry, started := c.getOrCreateCacheEntry(key, false)
+	if !started {
 		<-entry.done
 		return entry.url, entry.err
 	}
 
-	entry := &cacheEntry{done: make(chan struct{})}
-	c.inFlight[rawURL] = entry
-	c.mu.Unlock()
-
-	entry.url, entry.err = c.downloadAndCacheWithClient(ctx, rawURL, hashHex, parsed.Path, allowInsecure)
-
-	c.mu.Lock()
-	delete(c.inFlight, rawURL)
-	c.mu.Unlock()
-	close(entry.done)
+	entry.url, entry.err = c.downloadAndCacheWithClient(ctx, rawURL, lookup.hashHex, lookup.parsed.Path, allowInsecure, entry)
+	c.finishCacheEntry(key, entry)
 
 	return entry.url, entry.err
+}
+
+func (c *imageCache) CachedURLOrQueue(ctx context.Context, rawURL string, allowInsecure bool) (string, error) {
+	lookup, err := c.lookup(rawURL)
+	if err != nil || !lookup.cacheable || lookup.cachedURL != "" {
+		return lookup.cachedURL, err
+	}
+
+	key := imageCacheKey(rawURL, allowInsecure)
+	select {
+	case c.backgroundDownloads <- struct{}{}:
+	case <-ctx.Done():
+		return "", ctx.Err()
+	default:
+		return "", nil
+	}
+
+	entry, started := c.getOrCreateCacheEntry(key, true)
+	if !started {
+		<-c.backgroundDownloads
+		return "", nil
+	}
+
+	go func() {
+		defer func() { <-c.backgroundDownloads }()
+
+		entry.url, entry.err = c.downloadAndCacheWithClient(ctx, rawURL, lookup.hashHex, lookup.parsed.Path, allowInsecure, entry)
+		c.finishCacheEntry(key, entry)
+	}()
+
+	return "", nil
+}
+
+func (c *imageCache) ServeCachedOrInFlight(ctx context.Context, rawURL string, allowInsecure bool, w http.ResponseWriter) (string, bool, error) {
+	lookup, err := c.lookup(rawURL)
+	if err != nil || !lookup.cacheable || lookup.cachedURL != "" {
+		return lookup.cachedURL, false, err
+	}
+
+	key := imageCacheKey(rawURL, allowInsecure)
+	c.mu.Lock()
+	entry, ok := c.inFlight[key]
+	c.mu.Unlock()
+	if !ok {
+		return "", false, nil
+	}
+
+	select {
+	case <-entry.done:
+		return entry.url, false, entry.err
+	default:
+	}
+
+	select {
+	case <-entry.ready:
+	case <-ctx.Done():
+		return "", false, ctx.Err()
+	}
+
+	if entry.tmpPath == "" {
+		return "", false, entry.err
+	}
+
+	file, err := os.Open(entry.tmpPath)
+	if err != nil {
+		return "", false, err
+	}
+	defer file.Close()
+
+	w.Header().Set("Content-Type", entry.contentType)
+	w.Header().Set("Cache-Control", "public, max-age=2592000, immutable")
+	w.WriteHeader(http.StatusOK)
+
+	return "", true, streamGrowingFile(ctx, file, entry, w)
+}
+
+func (c *imageCache) CachedURLOrWait(ctx context.Context, rawURL string, allowInsecure bool) (string, error) {
+	lookup, err := c.lookup(rawURL)
+	if err != nil || !lookup.cacheable || lookup.cachedURL != "" {
+		return lookup.cachedURL, err
+	}
+
+	key := imageCacheKey(rawURL, allowInsecure)
+	c.mu.Lock()
+	entry, ok := c.inFlight[key]
+	c.mu.Unlock()
+	if !ok {
+		return "", nil
+	}
+
+	select {
+	case <-entry.done:
+		return entry.url, entry.err
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+func (c *imageCache) lookup(rawURL string) (imageCacheLookup, error) {
+	if c == nil || rawURL == "" {
+		return imageCacheLookup{}, nil
+	}
+
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return imageCacheLookup{}, err
+	}
+
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return imageCacheLookup{}, nil
+	}
+
+	hashHex := hashString(rawURL)
+	lookup := imageCacheLookup{
+		parsed:    parsed,
+		hashHex:   hashHex,
+		cacheable: true,
+	}
+
+	if existing, ok := c.findExistingFile(hashHex, parsed.Path); ok {
+		lookup.cachedURL = c.publicURL(existing)
+	}
+
+	return lookup, nil
+}
+
+func (c *imageCache) getOrCreateCacheEntry(key string, background bool) (*cacheEntry, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry, ok := c.inFlight[key]; ok {
+		return entry, false
+	}
+
+	entry := &cacheEntry{done: make(chan struct{}), ready: make(chan struct{}), background: background}
+	c.inFlight[key] = entry
+	return entry, true
+}
+
+func (c *imageCache) finishCacheEntry(key string, entry *cacheEntry) {
+	entry.readyOnce.Do(func() { close(entry.ready) })
+	c.mu.Lock()
+	delete(c.inFlight, key)
+	c.mu.Unlock()
+	close(entry.done)
+}
+
+func imageCacheKey(rawURL string, allowInsecure bool) string {
+	if allowInsecure {
+		return rawURL + "\x00insecure"
+	}
+
+	return rawURL
 }
 
 func (c *imageCache) findExistingFile(hashHex string, urlPath string) (string, bool) {
@@ -124,10 +273,10 @@ func (c *imageCache) findExistingFile(hashHex string, urlPath string) (string, b
 }
 
 func (c *imageCache) downloadAndCache(ctx context.Context, rawURL string, hashHex string, urlPath string) (string, error) {
-	return c.downloadAndCacheWithClient(ctx, rawURL, hashHex, urlPath, false)
+	return c.downloadAndCacheWithClient(ctx, rawURL, hashHex, urlPath, false, nil)
 }
 
-func (c *imageCache) downloadAndCacheWithClient(ctx context.Context, rawURL string, hashHex string, urlPath string, allowInsecure bool) (string, error) {
+func (c *imageCache) downloadAndCacheWithClient(ctx context.Context, rawURL string, hashHex string, urlPath string, allowInsecure bool, entry *cacheEntry) (string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
 		return "", err
@@ -146,19 +295,25 @@ func (c *imageCache) downloadAndCacheWithClient(ctx context.Context, rawURL stri
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("unexpected status code %d for %s", resp.StatusCode, rawURL)
 	}
+	contentType := resp.Header.Get("Content-Type")
 
 	ext := extensionFromPath(urlPath)
 	if ext == "" {
-		ext = extensionFromContentType(resp.Header.Get("Content-Type"))
+		ext = extensionFromContentType(contentType)
 	}
 	if ext == "" {
 		ext = ".img"
 	}
 
-	tmpPath := filepath.Join(c.dir, hashHex+".tmp")
-	file, err := os.Create(tmpPath)
+	file, err := os.CreateTemp(c.dir, hashHex+"-*.tmp")
 	if err != nil {
 		return "", err
+	}
+	tmpPath := file.Name()
+	if entry != nil {
+		entry.tmpPath = tmpPath
+		entry.contentType = contentType
+		entry.readyOnce.Do(func() { close(entry.ready) })
 	}
 
 	_, copyErr := io.Copy(file, resp.Body)
@@ -187,6 +342,43 @@ func (c *imageCache) downloadAndCacheWithClient(ctx context.Context, rawURL stri
 	return c.publicURL(filename), nil
 }
 
+func streamGrowingFile(ctx context.Context, file *os.File, entry *cacheEntry, dst io.Writer) error {
+	buf := make([]byte, 32*1024)
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	flusher, canFlush := dst.(http.Flusher)
+	var offset int64
+	for {
+		n, err := file.Read(buf)
+		if n > 0 {
+			offset += int64(n)
+			if _, writeErr := dst.Write(buf[:n]); writeErr != nil {
+				return writeErr
+			}
+			if canFlush {
+				flusher.Flush()
+			}
+		}
+		if err == nil {
+			continue
+		}
+		if err != io.EOF {
+			return err
+		}
+
+		select {
+		case <-entry.done:
+			if info, statErr := file.Stat(); statErr == nil && info.Size() > offset {
+				continue
+			}
+			return entry.err
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
 func (c *imageCache) publicURL(filename string) string {
 	if c.baseURL == "" {
 		return "/.cache/" + filename
@@ -201,7 +393,13 @@ func (c *imageCache) IsBuildingCache() bool {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return len(c.inFlight) > 0
+	for _, entry := range c.inFlight {
+		if !entry.background {
+			return true
+		}
+	}
+
+	return false
 }
 
 func extensionFromPath(path string) string {

--- a/internal/dynacat/image_cache_test.go
+++ b/internal/dynacat/image_cache_test.go
@@ -1,0 +1,201 @@
+package dynacat
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Uses a Jellyfin-style URL: /Items/movie-123/Images/Primary?api_key=jellyfin-token.
+// Verifies:
+// - SecureImageURL immediately returns /api/image-proxy/{hash}.
+// - Proxy URL does not expose the API key.
+// - Proxy registry keeps the real upstream URL.
+// - Background cache fetches the real upstream URL with the API key.
+// - Cached URL is /.cache/*.png and does not expose the API key.
+func TestSecureImageURLReturnsProxyThenBackgroundCachesMediaImage(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/Items/movie-123/Images/Primary" {
+			t.Fatalf("Expected media image path, got %q", r.URL.Path)
+		}
+		if r.URL.Query().Get("api_key") != "jellyfin-token" {
+			t.Fatalf("Expected API key query to be preserved for upstream fetch, got %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("poster image"))
+	}))
+	defer server.Close()
+
+	cache := newImageCache("", t.TempDir())
+	app := &application{
+		ctx:            context.Background(),
+		imageCache:     cache,
+		imageProxyURLs: make(map[string]imageProxyInfo),
+	}
+	providers := &widgetProviders{imageCache: cache, app: app}
+	imageURL := server.URL + "/Items/movie-123/Images/Primary?api_key=jellyfin-token"
+
+	proxiedURL := providers.SecureImageURL(context.Background(), imageURL, false)
+	if !strings.HasPrefix(proxiedURL, "/api/image-proxy/") {
+		t.Fatalf("Expected image proxy URL, got %q", proxiedURL)
+	}
+	if strings.Contains(proxiedURL, "jellyfin-token") {
+		t.Fatalf("Expected proxy URL not to expose API key, got %q", proxiedURL)
+	}
+	proxyInfo, ok := app.getImageProxyInfo(strings.TrimPrefix(proxiedURL, "/api/image-proxy/"))
+	if !ok {
+		t.Fatal("Expected proxy info to be registered")
+	}
+	if proxyInfo.URL != imageURL {
+		t.Fatalf("Expected proxy to retain upstream image URL, got %q", proxyInfo.URL)
+	}
+
+	cachedURL, err := cache.CachedURLOrWait(context.Background(), imageURL, false)
+	if err != nil {
+		t.Fatalf("Expected background cache to finish, got %v", err)
+	}
+	if !strings.HasPrefix(cachedURL, "/.cache/") || !strings.HasSuffix(cachedURL, ".png") {
+		t.Fatalf("Expected cached PNG URL, got %q", cachedURL)
+	}
+	if strings.Contains(cachedURL, "jellyfin-token") {
+		t.Fatalf("Expected cached URL not to expose API key, got %q", cachedURL)
+	}
+}
+
+// Uses a blocked httptest media server and fills all background image download slots.
+// Verifies:
+// - The over-limit image does not create new in-flight background work.
+// - The test then releases and waits for the queued downloads cleanly.
+func TestCachedURLOrQueueDropsNewBackgroundWorkWhenMediaServerIsSaturated(t *testing.T) {
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-release
+		w.Header().Set("Content-Type", "image/jpeg")
+		_, _ = w.Write([]byte("poster image"))
+	}))
+	defer server.Close()
+
+	cache := newImageCache("", t.TempDir())
+	queuedURLs := make([]string, 0, maxBackgroundImageDownloads)
+	for i := range maxBackgroundImageDownloads {
+		imageURL := fmt.Sprintf("%s/Items/movie-%d/Images/Primary?api_key=token-%d", server.URL, i, i)
+		_, err := cache.CachedURLOrQueue(context.Background(), imageURL, false)
+		if err != nil {
+			t.Fatalf("Expected no queue error for image %d, got %v", i, err)
+		}
+		queuedURLs = append(queuedURLs, imageURL)
+	}
+
+	overLimitURL := server.URL + "/Items/movie-over-limit/Images/Primary?api_key=token-over-limit"
+	cachedURL, err := cache.CachedURLOrQueue(context.Background(), overLimitURL, false)
+	if err != nil {
+		t.Fatalf("Expected no queue error when background limit is full, got %v", err)
+	}
+	if cachedURL != "" {
+		t.Fatalf("Expected no cached URL when background limit is full, got %q", cachedURL)
+	}
+
+	overLimitKey := imageCacheKey(overLimitURL, false)
+
+	cache.mu.Lock()
+	_, overLimitInFlight := cache.inFlight[overLimitKey]
+	cache.mu.Unlock()
+	if overLimitInFlight {
+		t.Fatal("Expected over-limit image not to create in-flight background work")
+	}
+
+	close(release)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	for _, queuedURL := range queuedURLs {
+		if _, err := cache.CachedURLOrWait(ctx, queuedURL, false); err != nil {
+			t.Fatalf("Expected queued image to finish after releasing media server, got %v", err)
+		}
+	}
+}
+
+func TestImageProxyStreamsInFlightBackgroundCacheWithoutSecondUpstreamFetch(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var requests int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&requests, 1) == 1 {
+			close(started)
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write([]byte("poster "))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		<-release
+		_, _ = w.Write([]byte("image"))
+	}))
+	defer server.Close()
+
+	cache := newImageCache("", t.TempDir())
+	imageURL := server.URL + "/Items/movie-123/Images/Primary?api_key=jellyfin-token"
+	if _, err := cache.CachedURLOrQueue(context.Background(), imageURL, false); err != nil {
+		t.Fatalf("Expected background cache to queue, got %v", err)
+	}
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("Expected background cache request to start")
+	}
+
+	proxyDone := make(chan []byte)
+	go func() {
+		recorder := httptest.NewRecorder()
+		cachedURL, streamed, err := cache.ServeCachedOrInFlight(context.Background(), imageURL, false, recorder)
+		if err != nil {
+			t.Errorf("Expected in-flight stream, got error %v", err)
+		}
+		if cachedURL != "" || !streamed {
+			t.Errorf("Expected in-flight stream, got cachedURL=%q streamed=%t", cachedURL, streamed)
+		}
+		proxyDone <- recorder.Body.Bytes()
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("Expected one upstream request while proxy streams in-flight cache, got %d", got)
+	}
+	close(release)
+
+	select {
+	case body := <-proxyDone:
+		if string(body) != "poster image" {
+			t.Fatalf("Expected proxy to stream full image, got %q", string(body))
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Expected proxy stream to finish")
+	}
+
+	if got := atomic.LoadInt32(&requests); got != 1 {
+		t.Fatalf("Expected cache and proxy to share one upstream request, got %d", got)
+	}
+	cachedURL, err := cache.CachedURLOrWait(context.Background(), imageURL, false)
+	if err != nil {
+		t.Fatalf("Expected cache to finish, got %v", err)
+	}
+	if !strings.HasPrefix(cachedURL, "/.cache/") {
+		t.Fatalf("Expected final cached URL, got %q", cachedURL)
+	}
+
+	cacheFile := strings.TrimPrefix(cachedURL, "/.cache/")
+	contents, err := os.ReadFile(filepath.Join(cache.dir, cacheFile))
+	if err != nil {
+		t.Fatalf("Expected cached file to exist, got %v", err)
+	}
+	if string(contents) != "poster image" {
+		t.Fatalf("Expected cached file to contain full image, got %q", string(contents))
+	}
+}

--- a/internal/dynacat/sse.go
+++ b/internal/dynacat/sse.go
@@ -92,6 +92,17 @@ func (a *application) handleImageProxyRequest(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	if a.imageCache != nil {
+		cachedURL, streamed, err := a.imageCache.ServeCachedOrInFlight(r.Context(), info.URL, info.AllowInsecure, w)
+		if streamed {
+			return
+		}
+		if err == nil && cachedURL != "" {
+			http.Redirect(w, r, cachedURL, http.StatusFound)
+			return
+		}
+	}
+
 	// Fetch the image using the stored URL with the appropriate client
 	client := ternary(info.AllowInsecure, defaultInsecureHTTPClient, defaultHTTPClient)
 	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, info.URL, nil)

--- a/internal/dynacat/widget-latest-media.go
+++ b/internal/dynacat/widget-latest-media.go
@@ -597,70 +597,25 @@ func (widget *latestMediaWidget) setProviders(providers *widgetProviders) {
 }
 
 func (widget *latestMediaWidget) cacheImageURLs() {
+	if widget.Providers == nil {
+		return
+	}
+
 	widget.mu.Lock()
 	defer widget.mu.Unlock()
 
-	ctx := context.Background()
 	for i := range widget.Items {
 		item := &widget.Items[i]
 		allowInsecure := widget.hostAllowInsecure[item.ServerURL]
 
 		// Process cover URL
 		if item.CoverURL != "" {
-			originalURL := item.CoverURL
-			hash := hashString(originalURL)
-
-			// Register with the application's image proxy
-			if widget.Providers != nil && widget.Providers.app != nil {
-				widget.Providers.app.registerImageProxy(hash, originalURL, allowInsecure)
-			}
-
-			// Try to cache the image
-			if widget.Providers != nil && widget.Providers.imageCache != nil {
-				cachedURL, err := widget.Providers.imageCache.CacheURLWithClient(ctx, originalURL, allowInsecure)
-				if err == nil && cachedURL != "" {
-					// Successfully cached, use the cached URL
-					item.CoverURL = cachedURL
-				} else {
-					// Failed to cache, use a proxy URL that doesn't expose the API key
-					item.CoverURL = fmt.Sprintf("/api/image-proxy/%s", hash)
-					if err != nil {
-						slog.Debug("failed to cache cover image, using proxy", "hash", hash, "error", stripAPIKeysFromError(err))
-					}
-				}
-			} else {
-				// No cache available, use proxy URL
-				item.CoverURL = fmt.Sprintf("/api/image-proxy/%s", hash)
-			}
+			item.CoverURL = widget.Providers.SecureImageURL(context.Background(), item.CoverURL, allowInsecure)
 		}
 
 		// Process thumbnail URL
 		if item.ThumbnailURL != "" {
-			originalURL := item.ThumbnailURL
-			hash := hashString(originalURL)
-
-			// Register with the application's image proxy
-			if widget.Providers != nil && widget.Providers.app != nil {
-				widget.Providers.app.registerImageProxy(hash, originalURL, allowInsecure)
-			}
-
-			// Try to cache the image
-			if widget.Providers != nil && widget.Providers.imageCache != nil {
-				cachedURL, err := widget.Providers.imageCache.CacheURLWithClient(ctx, originalURL, allowInsecure)
-				if err == nil && cachedURL != "" {
-					// Successfully cached, use the cached URL
-					item.ThumbnailURL = cachedURL
-				} else {
-					// Failed to cache, use a proxy URL that doesn't expose the API key
-					item.ThumbnailURL = fmt.Sprintf("/api/image-proxy/%s", hash)
-					if err != nil {
-						slog.Debug("failed to cache thumbnail image, using proxy", "hash", hash, "error", stripAPIKeysFromError(err))
-					}
-				}
-			} else {
-				// No cache available, use proxy URL
-				item.ThumbnailURL = fmt.Sprintf("/api/image-proxy/%s", hash)
-			}
+			item.ThumbnailURL = widget.Providers.SecureImageURL(context.Background(), item.ThumbnailURL, allowInsecure)
 		}
 	}
 }

--- a/internal/dynacat/widget.go
+++ b/internal/dynacat/widget.go
@@ -211,12 +211,18 @@ func (p *widgetProviders) SecureImageURL(ctx context.Context, imageURL string, a
 		p.app.registerImageProxy(hash, imageURL, allowInsecure)
 	}
 
-	// Try to cache the image
+	// Try to cache the image without blocking widget rendering.
 	if p.imageCache != nil {
-		cachedURL, err := p.imageCache.CacheURLWithClient(ctx, imageURL, allowInsecure)
+		cacheCtx := ctx
+		if p.app != nil {
+			cacheCtx = p.app.ctx
+		}
+		cachedURL, err := p.imageCache.CachedURLOrQueue(cacheCtx, imageURL, allowInsecure)
 		if err == nil && cachedURL != "" {
-			// Successfully cached, return the cached URL
 			return cachedURL
+		}
+		if err != nil {
+			slog.Debug("failed to queue image cache, using proxy", "hash", hash, "error", stripAPIKeysFromError(err))
 		}
 	}
 


### PR DESCRIPTION
Previously, cache misses for remote images blocked widget rendering because the server downloaded images before returning widget HTML. Widgets could delay first page load while avatars, thumbnails, or previews were cached.

Now, cached images are used immediately when available. On cache miss, the server returns a safe proxy URL right away and warms the image cache in the background, so widgets render without waiting on image downloads. Proxy requests also reuse in-flight cache fills to avoid duplicate remote fetches.