### PR TITLE
WIP: Hoverable Reddit thumbnails

### DIFF
--- a/internal/dynacat/static/css/widget-reddit.css
+++ b/internal/dynacat/static/css/widget-reddit.css
@@ -20,3 +20,53 @@
     inset: 0;
     background: linear-gradient(0deg, var(--color-widget-background) 10%, transparent);
 }
+
+.reddit-hover-media {
+    display: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+    .reddit-thumbnail-preview {
+        flex-shrink: 0;
+    }
+
+    .reddit-hover-media.reddit-hover-media-visible {
+        position: fixed;
+        display: block;
+        top: 0;
+        left: 0;
+        --reddit-hover-max-width: 82rem;
+        --reddit-hover-max-height: 52rem;
+        width: auto;
+        max-width: min(var(--reddit-hover-max-width), calc(100vw - 1rem));
+        max-height: min(var(--reddit-hover-max-height), calc(100vh - 1rem));
+        height: auto;
+        object-fit: contain;
+        border: 1px solid var(--color-separator);
+        border-radius: var(--border-radius);
+        background: var(--color-widget-background);
+        box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.35);
+        pointer-events: none;
+        transform: translate(var(--reddit-hover-x), var(--reddit-hover-y));
+        z-index: 20;
+    }
+
+    .reddit-hover-media.reddit-hover-media-wide {
+        --reddit-hover-max-width: 96rem;
+        --reddit-hover-max-height: 42rem;
+    }
+
+    .reddit-hover-media.reddit-hover-media-tall {
+        --reddit-hover-max-width: 42rem;
+        --reddit-hover-max-height: 62rem;
+    }
+
+    .reddit-card-thumbnail-container:hover {
+        overflow: visible;
+        z-index: 20;
+    }
+
+    .reddit-card-thumbnail-container:hover::after {
+        display: none;
+    }
+}

--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -708,6 +708,81 @@ function setupLazyImages() {
     }
 }
 
+function setupRedditImagePreviews() {
+    if (!document.querySelector(".reddit-hover-media")) {
+        return;
+    }
+
+    if (!window.matchMedia("(hover: hover) and (pointer: fine)").matches) {
+        return;
+    }
+
+    const containers = document.querySelectorAll(".reddit-thumbnail-preview, .reddit-card-thumbnail-container");
+
+    for (const container of containers) {
+        if (container.dataset.redditPreviewInitialized) continue;
+
+        const media = container.querySelector(".reddit-hover-media");
+        if (!media) continue;
+
+        container.dataset.redditPreviewInitialized = "true";
+
+        const positionMedia = () => {
+            const gap = 16;
+            const padding = 8;
+            const containerRect = container.getBoundingClientRect();
+            const mediaRect = media.getBoundingClientRect();
+            let x = containerRect.right + gap;
+            let y = containerRect.top + containerRect.height / 2 - mediaRect.height / 2;
+
+            if (x + mediaRect.width > window.innerWidth - padding) {
+                x = containerRect.left - mediaRect.width - gap;
+            }
+
+            if (y + mediaRect.height > window.innerHeight - padding) {
+                y = window.innerHeight - mediaRect.height - padding;
+            }
+
+            media.style.setProperty("--reddit-hover-x", Math.max(padding, x) + "px");
+            media.style.setProperty("--reddit-hover-y", Math.max(padding, y) + "px");
+        };
+
+        container.addEventListener("mouseenter", () => {
+            if (!media.src) {
+                media.src = media.dataset.src;
+            }
+
+            media.classList.add("reddit-hover-media-visible");
+            positionMedia();
+
+            if (media.tagName === "VIDEO") {
+                media.play().catch(() => {});
+            }
+        });
+
+        const updateMediaShape = () => {
+            const width = media.videoWidth || media.naturalWidth;
+            const height = media.videoHeight || media.naturalHeight;
+            if (!width || !height) return;
+
+            media.classList.toggle("reddit-hover-media-wide", width / height >= 2);
+            media.classList.toggle("reddit-hover-media-tall", height / width >= 1.6);
+            positionMedia();
+        };
+
+        media.addEventListener("load", updateMediaShape);
+        media.addEventListener("loadedmetadata", updateMediaShape);
+
+        container.addEventListener("mouseleave", () => {
+            media.classList.remove("reddit-hover-media-visible");
+            if (media.tagName === "VIDEO") {
+                media.pause();
+                media.currentTime = 0;
+            }
+        });
+    }
+}
+
 function getCollapsibleContainerStates(element) {
     const allContainers = [...element.querySelectorAll('.collapsible-container')];
     return allContainers.map((container) => container.classList.contains('container-expanded'));
@@ -1347,6 +1422,7 @@ async function setupPage() {
         setupDynamicRelativeTime();
         setupImageFallbacks();
         setupLazyImages();
+        setupRedditImagePreviews();
         setupPlayingProgressUpdater();
     } finally {
         pageElement.classList.add("content-ready");
@@ -1450,6 +1526,7 @@ async function updateWidget(widgetElement) {
             setupDynamicRelativeTime();
             setupImageFallbacks();
             setupLazyImages();
+            setupRedditImagePreviews();
             setupTruncatedElementTitles();
 
             const newCallbacks = contentReadyCallbacks.splice(callbacksIndexBefore);

--- a/internal/dynacat/templates/forum-posts.html
+++ b/internal/dynacat/templates/forum-posts.html
@@ -13,7 +13,18 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 21 3 16.5m0 0L7.5 12M3 16.5h13.5m0-13.5L21 7.5m0 0L16.5 12M21 7.5H7.5" />
             </svg>
             {{- else if .ThumbnailUrl }}
+            {{- if or .PreviewImageUrl .PreviewVideoUrl }}
+            <span class="reddit-thumbnail-preview">
+                <img class="forum-post-list-thumbnail thumbnail" src="{{ .ThumbnailUrl }}" alt="" loading="lazy">
+                {{- if .PreviewVideoUrl }}
+                <video class="reddit-hover-media" data-src="{{ .PreviewVideoUrl }}" muted loop playsinline></video>
+                {{- else }}
+                <img class="reddit-hover-media" data-src="{{ .PreviewImageUrl }}" alt="">
+                {{- end }}
+            </span>
+            {{- else }}
             <img class="forum-post-list-thumbnail thumbnail" src="{{ .ThumbnailUrl }}" alt="" loading="lazy">
+            {{- end }}
             {{- else if .TargetUrl }}
             <svg class="forum-post-list-thumbnail hide-on-mobile" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="-9 -8 40 40" stroke-width="1.5" stroke="var(--color-text-subdue)">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />

--- a/internal/dynacat/templates/reddit-horizontal-cards.html
+++ b/internal/dynacat/templates/reddit-horizontal-cards.html
@@ -10,6 +10,11 @@
             {{ if ne "" .ThumbnailUrl }}
             <div class="reddit-card-thumbnail-container">
                 <img class="reddit-card-thumbnail" loading="lazy" src="{{ .ThumbnailUrl }}" alt="">
+                {{ if ne "" .PreviewVideoUrl }}
+                <video class="reddit-hover-media" data-src="{{ .PreviewVideoUrl }}" muted loop playsinline></video>
+                {{ else if ne "" .PreviewImageUrl }}
+                <img class="reddit-hover-media" data-src="{{ .PreviewImageUrl }}" alt="">
+                {{ end }}
             </div>
             {{ end }}
             <div class="padding-widget flex flex-column grow relative">

--- a/internal/dynacat/templates/reddit-vertical-cards.html
+++ b/internal/dynacat/templates/reddit-vertical-cards.html
@@ -9,6 +9,11 @@
         {{ if ne "" .ThumbnailUrl }}
         <div class="reddit-card-thumbnail-container">
             <img class="reddit-card-thumbnail" loading="lazy" src="{{ .ThumbnailUrl }}" alt="">
+            {{ if ne "" .PreviewVideoUrl }}
+            <video class="reddit-hover-media" data-src="{{ .PreviewVideoUrl }}" muted loop playsinline></video>
+            {{ else if ne "" .PreviewImageUrl }}
+            <img class="reddit-hover-media" data-src="{{ .PreviewImageUrl }}" alt="">
+            {{ end }}
         </div>
         {{ end }}
         <div class="padding-widget relative">

--- a/internal/dynacat/widget-reddit.go
+++ b/internal/dynacat/widget-reddit.go
@@ -112,16 +112,23 @@ func (widget *redditWidget) update(ctx context.Context) {
 		posts.sortByEngagement()
 	}
 
-	if widget.Providers != nil {
+	if widget.needsImages() && widget.Providers != nil {
 		for i := range posts {
-			if posts[i].ThumbnailUrl == "" {
-				continue
+			if posts[i].ThumbnailUrl != "" {
+				posts[i].ThumbnailUrl = widget.Providers.SecureImageURL(ctx, posts[i].ThumbnailUrl, false)
 			}
-			posts[i].ThumbnailUrl = widget.Providers.SecureImageURL(ctx, posts[i].ThumbnailUrl, false)
+
+			if posts[i].PreviewImageUrl != "" {
+				posts[i].PreviewImageUrl = widget.Providers.SecureImageURL(ctx, posts[i].PreviewImageUrl, false)
+			}
 		}
 	}
 
 	widget.Posts = posts
+}
+
+func (widget *redditWidget) needsImages() bool {
+	return widget.ShowThumbnails || widget.Style == "horizontal-cards" || widget.Style == "vertical-cards"
 }
 
 func (widget *redditWidget) Render() template.HTML {
@@ -134,7 +141,6 @@ func (widget *redditWidget) Render() template.HTML {
 	}
 
 	return widget.renderTemplate(widget, forumPostsTemplate)
-
 }
 
 type subredditResponseJson struct {
@@ -154,7 +160,44 @@ type subredditResponseJson struct {
 				IsSelf        bool    `json:"is_self"`
 				Thumbnail     string  `json:"thumbnail"`
 				Flair         string  `json:"link_flair_text"`
-				ParentList    []struct {
+				Media         struct {
+					RedditVideo struct {
+						FallbackUrl string `json:"fallback_url"`
+					} `json:"reddit_video"`
+				} `json:"media"`
+				SecureMedia struct {
+					RedditVideo struct {
+						FallbackUrl string `json:"fallback_url"`
+					} `json:"reddit_video"`
+				} `json:"secure_media"`
+				Preview struct {
+					Images []struct {
+						Source struct {
+							Url string `json:"url"`
+						} `json:"source"`
+						Variants struct {
+							Gif struct {
+								Source struct {
+									Url string `json:"url"`
+								} `json:"source"`
+							} `json:"gif"`
+						} `json:"variants"`
+					} `json:"images"`
+				} `json:"preview"`
+				GalleryData struct {
+					Items []struct {
+						MediaId string `json:"media_id"`
+					} `json:"items"`
+				} `json:"gallery_data"`
+				MediaMetadata map[string]struct {
+					Previews []struct {
+						Url string `json:"u"`
+					} `json:"p"`
+					Source struct {
+						Url string `json:"u"`
+					} `json:"s"`
+				} `json:"media_metadata"`
+				ParentList []struct {
 					Id        string `json:"id"`
 					Subreddit string `json:"subreddit"`
 					Permalink string `json:"permalink"`
@@ -180,6 +223,17 @@ func buildRedditRequestURL(baseURL, path string, query url.Values) string {
 	}
 
 	return baseURL + path + "?" + encodedQuery
+}
+
+func redditDirectImageURL(postURL string) string {
+	lowerURL := strings.ToLower(postURL)
+	lowerURL = strings.Split(lowerURL, "?")[0]
+
+	if strings.HasSuffix(lowerURL, ".jpg") || strings.HasSuffix(lowerURL, ".jpeg") || strings.HasSuffix(lowerURL, ".png") || strings.HasSuffix(lowerURL, ".webp") || strings.HasSuffix(lowerURL, ".gif") {
+		return postURL
+	}
+
+	return ""
 }
 
 func (widget *redditWidget) fetchSubredditPosts() (forumPostList, error) {
@@ -293,6 +347,52 @@ func (widget *redditWidget) fetchSubredditPosts() (forumPostList, error) {
 
 		if post.Thumbnail != "" && post.Thumbnail != "self" && post.Thumbnail != "default" && post.Thumbnail != "nsfw" {
 			forumPost.ThumbnailUrl = html.UnescapeString(post.Thumbnail)
+		}
+
+		if len(post.GalleryData.Items) > 0 {
+			media := post.MediaMetadata[post.GalleryData.Items[0].MediaId]
+			if media.Source.Url != "" {
+				forumPost.PreviewImageUrl = html.UnescapeString(media.Source.Url)
+			}
+			if len(media.Previews) > 0 && media.Previews[0].Url != "" {
+				forumPost.ThumbnailUrl = html.UnescapeString(media.Previews[0].Url)
+			}
+		}
+
+		for _, media := range post.MediaMetadata {
+			if forumPost.PreviewImageUrl != "" {
+				break
+			}
+
+			if forumPost.ThumbnailUrl == "" || strings.Contains(forumPost.ThumbnailUrl, "external-preview.redd.it") {
+				if len(media.Previews) > 0 && media.Previews[0].Url != "" {
+					forumPost.ThumbnailUrl = html.UnescapeString(media.Previews[0].Url)
+				}
+			}
+
+			if media.Source.Url != "" {
+				forumPost.PreviewImageUrl = html.UnescapeString(media.Source.Url)
+				break
+			}
+		}
+
+		if forumPost.PreviewImageUrl == "" {
+			forumPost.PreviewImageUrl = html.UnescapeString(redditDirectImageURL(post.Url))
+		}
+
+		if forumPost.PreviewImageUrl == "" && len(post.Preview.Images) > 0 {
+			image := post.Preview.Images[0]
+			if image.Variants.Gif.Source.Url != "" {
+				forumPost.PreviewImageUrl = html.UnescapeString(image.Variants.Gif.Source.Url)
+			} else if image.Source.Url != "" {
+				forumPost.PreviewImageUrl = html.UnescapeString(image.Source.Url)
+			}
+		}
+
+		if post.SecureMedia.RedditVideo.FallbackUrl != "" {
+			forumPost.PreviewVideoUrl = html.UnescapeString(post.SecureMedia.RedditVideo.FallbackUrl)
+		} else if post.Media.RedditVideo.FallbackUrl != "" {
+			forumPost.PreviewVideoUrl = html.UnescapeString(post.Media.RedditVideo.FallbackUrl)
 		}
 
 		if !post.IsSelf {

--- a/internal/dynacat/widget-shared.go
+++ b/internal/dynacat/widget-shared.go
@@ -14,6 +14,8 @@ type forumPost struct {
 	TargetUrl       string
 	TargetUrlDomain string
 	ThumbnailUrl    string
+	PreviewImageUrl string
+	PreviewVideoUrl string
 	CommentCount    int
 	Score           int
 	Engagement      float64


### PR DESCRIPTION
WIP / DONT MERGE / NOT TESTED PROPERLY YET / DISCUSSION OPENED

I want to see reddit thumbnails from dynacat, including gifs/videos.

PR also fixes some thumbnails that were picked wrong (for example, post might have some picture inside and github link and there was ugly github link preview in such cases). Example: https://www.reddit.com/r/LETFs/comments/1tijpvi/i_got_curious_about_leveraged_etfs_and_decided_to/


https://github.com/user-attachments/assets/2f1df0bb-c633-4a4e-819b-ac0902645212

---

Things left to test/discuss:

- all reddit widget formats (cards)
- more media formats (hevc/mp4? does reddit use that?)
- nsfw (didnt check it lul but do they need user age and so on)
- does clean browser allows autoplay muted videos from reddit if not entered it (seems yes, but to check)
- more media sizes (weird height/width dimensions)
- i am not sure about the code and actually I want to start splitting js, its large
- this doesnt use server caching mechanism, I am not sure it is ready to work with videos and didn't want to pollute server, its browser-only image lazy-loading now
- is it viable to support showing multiple images with mouse-scrolling, since we already preview videos