### PR TITLE
Add minimal mode and configurable chart days for markets widget

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1808,7 +1808,7 @@ The sort order in which posts are returned. Possible options are `hot` and `new`
 Limit to posts containing one of the given tags. **You cannot specify a sort order when filtering by tags, it will default to `hot`.**
 
 ### Markets
-Display a list of markets, their current value, change for the day and a small 21d chart. Data is taken from Yahoo Finance.
+Display a list of markets, their current value, change for the day and a small chart. Data is taken from Yahoo Finance.
 
 Example:
 
@@ -1837,14 +1837,23 @@ Preview:
 | ---- | ---- | -------- |
 | markets | array | yes |
 | sort-by | string | no |
+| chart-days | integer | no |
+| minimal | boolean | no |
 | chart-link-template | string | no |
 | symbol-link-template | string | no |
+| proxy | string | no |
 
 ##### `markets`
 An array of markets for which to display information about.
 
 ##### `sort-by`
 By default the markets are displayed in the order they were defined. You can customize their ordering by setting the `sort-by` property to `change` for descending order based on the stock's percentage change (e.g. 1% would be sorted higher than -1%) or `absolute-change` for descending order based on the stock's absolute price change (e.g. -1% would be sorted higher than +0.5%).
+
+##### `chart-days`
+How many daily close prices to show in the chart. This is based on available trading/data days, not calendar days. The default is `21`.
+
+##### `minimal`
+When set to `true`, shows only the configured name and percentage in a more compact layout. Hovering the name shows the symbol, and hovering the percentage shows the current price.
 
 ##### `chart-link-template`
 A template for the link to go to when clicking on the chart that will be applied to all markets. The value `{SYMBOL}` will be replaced with the symbol of the market. You can override this on a per-market basis by specifying a `chart-link` property. Example:
@@ -1859,6 +1868,9 @@ A template for the link to go to when clicking on the symbol that will be applie
 ```yaml
 symbol-link-template: https://www.google.com/search?tbm=nws&q={SYMBOL}
 ```
+
+##### `proxy`
+Proxy URL to use for Yahoo Finance requests.
 
 ###### Properties for each market
 | Name | Type | Required |

--- a/internal/dynacat/static/css/widget-markets.css
+++ b/internal/dynacat/static/css/widget-markets.css
@@ -1,13 +1,75 @@
-.market-chart {
-    margin-left: auto;
-    width: 6.5rem;
-    flex-shrink: 0;
+.market-row {
+    display: grid;
+    grid-template-columns: minmax(0, 12rem) minmax(5rem, 1fr) max-content;
+    align-items: center;
+    column-gap: 1rem;
 }
 
-.market-chart svg {
+.market-info {
+    min-width: 0;
+}
+
+.market-chart-link {
+    min-width: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.market-chart {
+    display: block;
     width: 100%;
 }
 
 .market-values {
-    min-width: 8rem;
+    min-width: max-content;
+}
+
+.market-list-minimal {
+    --list-half-gap: 0.12rem;
+    gap: 0;
+}
+
+.market-list-minimal > .market-row {
+    grid-template-columns: var(--market-name-width) minmax(5.5rem, 1fr) max-content;
+    column-gap: 0.75rem;
+    padding-block: var(--list-half-gap);
+    padding-left: 0;
+    border-left: none;
+}
+
+.market-list-minimal.list-with-separator > .market-row:not(:first-child) {
+    margin-top: 0;
+    padding-top: var(--list-half-gap);
+    border-top: none;
+}
+
+.market-list-minimal .market-row:first-child {
+    padding-top: 0;
+}
+
+.market-list-minimal .market-row:last-child {
+    padding-bottom: 0;
+}
+
+.market-list-minimal .market-chart-link .market-chart {
+    width: 6.5rem;
+    margin-inline: auto;
+}
+
+.market-list-minimal .market-chart {
+    height: 2rem;
+}
+
+.market-list-minimal .market-chart polyline {
+    stroke-width: 1.2px;
+}
+
+.market-list-minimal .market-values {
+    line-height: 1;
+    white-space: nowrap;
+}
+
+.market-list-minimal .size-h3 {
+    font-size: 1.25rem;
 }

--- a/internal/dynacat/templates/markets.html
+++ b/internal/dynacat/templates/markets.html
@@ -3,23 +3,37 @@
 {{ define "widget-content-classes" }}{{ if .Frameless }}widget-content-frameless{{ end }}{{ end }}
 
 {{ define "widget-content" }}
-<div class="dynamic-columns list-gap-20 list-with-separator">
+<div class="dynamic-columns list-gap-20 list-with-separator market-list{{ if .Minimal }} market-list-minimal{{ end }}"{{ if .Minimal }} style="--market-name-width: {{ .MinimalNameWidth }};"{{ end }}>
     {{ range .Markets }}
-    <div class="flex items-center gap-15">
-        <div class="min-width-0">
+    <div class="market-row">
+        <div class="market-info">
+            {{ if $.Minimal }}
+            {{ if .CustomName }}
+            <a{{ if ne "" .SymbolLink }} href="{{ .SymbolLink }}" target="_blank" rel="noreferrer"{{ end }} class="color-highlight size-h3 block text-truncate cursor-help" data-popover-type="text" data-popover-position="above" data-popover-text="{{ .Symbol }}" aria-label="{{ .Symbol }}">{{ .CustomName }}</a>
+            {{ else }}
+            <a{{ if ne "" .SymbolLink }} href="{{ .SymbolLink }}" target="_blank" rel="noreferrer"{{ end }} class="color-highlight size-h3 block text-truncate">{{ .Symbol }}</a>
+            {{ end }}
+            {{ else }}
             <a{{ if ne "" .SymbolLink }} href="{{ .SymbolLink }}" target="_blank" rel="noreferrer"{{ end }} class="color-highlight size-h3 block text-truncate">{{ .Symbol }}</a>
             <div class="text-truncate">{{ .Name }}</div>
+            {{ end }}
         </div>
 
-        <a class="market-chart" {{ if ne "" .ChartLink }} href="{{ .ChartLink }}" target="_blank" rel="noreferrer"{{ end }}>
+        {{ if ne "" .SvgChartPoints }}
+        <a class="market-chart-link" {{ if ne "" .ChartLink }} href="{{ .ChartLink }}" target="_blank" rel="noreferrer"{{ end }}>
             <svg class="market-chart shrink-0" viewBox="0 0 100 50">
                 <polyline fill="none" stroke="var(--color-text-subdue)" stroke-linejoin="round" stroke-width="1.5px" points="{{ .SvgChartPoints }}" vector-effect="non-scaling-stroke"></polyline>
             </svg>
         </a>
+        {{ else }}
+        <div class="market-chart-link"></div>
+        {{ end }}
 
         <div class="market-values shrink-0">
-            <div class="size-h3 text-right {{ if eq .PercentChange 0.0 }}{{ else if gt .PercentChange 0.0 }}{{ if .InvertColors }}color-negative{{ else }}color-positive{{ end }}{{ else }}{{ if .InvertColors }}color-positive{{ else }}color-negative{{ end }}{{ end }}">{{ printf "%+.2f" .PercentChange }}%</div>
+            <div class="size-h3 text-right {{ if $.Minimal }}cursor-help {{ end }}{{ if eq .PercentChange 0.0 }}{{ else if gt .PercentChange 0.0 }}{{ if .InvertColors }}color-negative{{ else }}color-positive{{ end }}{{ else }}{{ if .InvertColors }}color-positive{{ else }}color-negative{{ end }}{{ end }}"{{ if $.Minimal }} data-popover-type="text" data-popover-position="above" data-popover-text="{{ .Currency }}{{ .Price | formatPriceWithPrecision .PriceHint }}" aria-label="{{ .Currency }}{{ .Price | formatPriceWithPrecision .PriceHint }}"{{ end }}>{{ printf "%+.2f" .PercentChange }}%</div>
+            {{ if not $.Minimal }}
             <div class="text-right">{{ .Currency }}{{ .Price | formatPriceWithPrecision .PriceHint }}</div>
+            {{ end }}
         </div>
     </div>
     {{ end }}

--- a/internal/dynacat/utils.go
+++ b/internal/dynacat/utils.go
@@ -52,8 +52,18 @@ func svgPolylineCoordsFromYValues(width float64, height float64, values []float6
 	distanceBetweenPoints := width / float64(len(values)-1)
 	min := slices.Min(values)
 	max := slices.Max(values)
+	midpoint := height/2 + verticalPadding
 
 	for i := range values {
+		if max == min {
+			coordinates[i] = fmt.Sprintf(
+				"%.2f,%.2f",
+				float64(i)*distanceBetweenPoints,
+				midpoint,
+			)
+			continue
+		}
+
 		coordinates[i] = fmt.Sprintf(
 			"%.2f,%.2f",
 			float64(i)*distanceBetweenPoints,

--- a/internal/dynacat/widget-markets.go
+++ b/internal/dynacat/widget-markets.go
@@ -2,6 +2,8 @@ package dynacat
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"log/slog"
@@ -15,6 +17,8 @@ import (
 
 var marketsWidgetTemplate = mustParseTemplate("markets.html", "widget-base.html")
 
+const defaultMarketChartDays = 21
+
 type marketsWidget struct {
 	widgetBase         `yaml:",inline"`
 	Frameless          bool            `yaml:"frameless"`
@@ -22,10 +26,35 @@ type marketsWidget struct {
 	MarketRequests     []marketRequest `yaml:"markets"`
 	ChartLinkTemplate  string          `yaml:"chart-link-template"`
 	SymbolLinkTemplate string          `yaml:"symbol-link-template"`
+	ChartDays          int             `yaml:"chart-days"`
+	Minimal            bool            `yaml:"minimal"`
 	Sort               string          `yaml:"sort-by"`
 	Proxy              string          `yaml:"proxy"`
 	Markets            marketList      `yaml:"-"`
 	httpClient         *http.Client    `yaml:"-"`
+}
+
+func (widget *marketsWidget) MinimalNameWidth() string {
+	width := 0
+
+	for i := range widget.Markets {
+		name := widget.Markets[i].CustomName
+		if name == "" {
+			name = widget.Markets[i].Symbol
+		}
+
+		width = max(width, len([]rune(name)))
+	}
+
+	if width > 12 {
+		width = 12
+	}
+
+	if width < 3 {
+		width = 3
+	}
+
+	return fmt.Sprintf("%dch", width)
 }
 
 func (widget *marketsWidget) initialize() error {
@@ -35,6 +64,13 @@ func (widget *marketsWidget) initialize() error {
 	if widget.UpdateInterval == nil {
 		interval := updateIntervalField(10 * time.Minute)
 		widget.UpdateInterval = &interval
+	}
+
+	switch {
+	case widget.ChartDays == 0:
+		widget.ChartDays = defaultMarketChartDays
+	case widget.ChartDays < 2:
+		return errors.New("chart-days must be greater than 1")
 	}
 
 	transport := &http.Transport{
@@ -60,8 +96,21 @@ func (widget *marketsWidget) initialize() error {
 		widget.MarketRequests = widget.StocksRequests
 	}
 
+	if len(widget.MarketRequests) == 0 {
+		return errors.New("markets must contain at least one market")
+	}
+
+	if widget.Sort != "" && widget.Sort != "change" && widget.Sort != "absolute-change" {
+		return errors.New("sort-by must be one of: change, absolute-change")
+	}
+
 	for i := range widget.MarketRequests {
 		m := &widget.MarketRequests[i]
+
+		if strings.TrimSpace(m.Symbol) == "" {
+			return errors.New("market symbol is required")
+		}
+		m.Symbol = strings.TrimSpace(m.Symbol)
 
 		if widget.ChartLinkTemplate != "" && m.ChartLink == "" {
 			m.ChartLink = strings.ReplaceAll(widget.ChartLinkTemplate, "{SYMBOL}", m.Symbol)
@@ -76,7 +125,7 @@ func (widget *marketsWidget) initialize() error {
 }
 
 func (widget *marketsWidget) update(ctx context.Context) {
-	markets, err := fetchMarketsDataFromYahoo(widget.MarketRequests, widget.httpClient)
+	markets, err := fetchMarketsDataFromYahoo(ctx, widget.MarketRequests, widget.ChartDays, widget.httpClient)
 
 	if !widget.canContinueUpdateAfterHandlingErr(err) {
 		return
@@ -140,21 +189,75 @@ type marketResponseJson struct {
 			} `json:"meta"`
 			Indicators struct {
 				Quote []struct {
-					Close []float64 `json:"close,omitempty"`
+					Close marketClosePrices `json:"close,omitempty"`
 				} `json:"quote"`
 			} `json:"indicators"`
 		} `json:"result"`
 	} `json:"chart"`
 }
 
-// TODO: allow changing chart time frame
-const marketChartDays = 21
+type marketClosePrices []float64
 
-func fetchMarketsDataFromYahoo(marketRequests []marketRequest, client *http.Client) (marketList, error) {
-	requests := make([]*http.Request, 0, len(marketRequests))
+func (prices *marketClosePrices) UnmarshalJSON(data []byte) error {
+	var values []*float64
+	if err := json.Unmarshal(data, &values); err != nil {
+		return err
+	}
+
+	closePrices := make([]float64, 0, len(values))
+	seenPrice := false
+	for i := range values {
+		if values[i] == nil && !seenPrice {
+			continue
+		}
+
+		if values[i] != nil {
+			seenPrice = true
+			closePrices = append(closePrices, *values[i])
+		} else {
+			closePrices = append(closePrices, 0)
+		}
+	}
+
+	*prices = closePrices
+	return nil
+}
+
+func fetchMarketsDataFromYahoo(ctx context.Context, marketRequests []marketRequest, chartDays int, client requestDoer) (marketList, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	if chartDays == 0 {
+		chartDays = defaultMarketChartDays
+	}
+
+	symbols := make([]string, 0, len(marketRequests))
+	seenSymbols := make(map[string]struct{}, len(marketRequests))
 
 	for i := range marketRequests {
-		request, _ := http.NewRequest("GET", fmt.Sprintf("https://query1.finance.yahoo.com/v8/finance/chart/%s?range=1mo&interval=1d", marketRequests[i].Symbol), nil)
+		symbol := strings.TrimSpace(marketRequests[i].Symbol)
+		if symbol == "" {
+			continue
+		}
+
+		if _, ok := seenSymbols[symbol]; ok {
+			continue
+		}
+
+		seenSymbols[symbol] = struct{}{}
+		symbols = append(symbols, symbol)
+	}
+
+	requests := make([]*http.Request, 0, len(symbols))
+	rangeParam := yahooChartRangeForDays(chartDays)
+
+	for i := range symbols {
+		request, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("https://query1.finance.yahoo.com/v8/finance/chart/%s?range=%s&interval=1d", url.PathEscape(symbols[i]), rangeParam), nil)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %v", errNoContent, err)
+		}
+
 		setBrowserUserAgentHeader(request)
 		requests = append(requests, request)
 	}
@@ -165,62 +268,46 @@ func fetchMarketsDataFromYahoo(marketRequests []marketRequest, client *http.Clie
 		return nil, fmt.Errorf("%w: %v", errNoContent, err)
 	}
 
-	markets := make(marketList, 0, len(responses))
+	responsesBySymbol := make(map[string]marketResponseJson, len(responses))
+	errsBySymbol := make(map[string]error, len(responses))
 	var failed int
 
 	for i := range responses {
 		if errs[i] != nil {
-			failed++
-			slog.Error("Failed to fetch market data", "symbol", marketRequests[i].Symbol, "error", errs[i])
+			errsBySymbol[symbols[i]] = errs[i]
+			slog.Error("Failed to fetch market data", "symbol", symbols[i], "error", errs[i])
 			continue
 		}
 
-		response := responses[i]
+		responsesBySymbol[symbols[i]] = responses[i]
+	}
 
-		if len(response.Chart.Result) == 0 {
+	markets := make(marketList, 0, len(marketRequests))
+
+	for i := range marketRequests {
+		request := marketRequests[i]
+		symbol := strings.TrimSpace(request.Symbol)
+
+		if err := errsBySymbol[symbol]; err != nil {
 			failed++
-			slog.Error("Market response contains no data", "symbol", marketRequests[i].Symbol)
 			continue
 		}
 
-		result := &response.Chart.Result[0]
-		prices := result.Indicators.Quote[0].Close
-
-		if len(prices) > marketChartDays {
-			prices = prices[len(prices)-marketChartDays:]
+		response, ok := responsesBySymbol[symbol]
+		if !ok {
+			failed++
+			slog.Error("Market response contains no data", "symbol", symbol)
+			continue
 		}
 
-		previous := result.Meta.ChartPreviousClose
-		if previous == 0 {
-			previous = result.Meta.RegularMarketPrice
+		market, err := marketFromYahooResponse(request, response, chartDays)
+		if err != nil {
+			failed++
+			slog.Error("Failed to parse market data", "symbol", symbol, "error", err)
+			continue
 		}
 
-		if len(prices) >= 2 && prices[len(prices)-2] != 0 {
-			previous = prices[len(prices)-2]
-		}
-
-		points := svgPolylineCoordsFromYValues(100, 50, maybeCopySliceWithoutZeroValues(prices))
-
-		currency, exists := currencyToSymbol[strings.ToUpper(result.Meta.Currency)]
-		if !exists {
-			currency = result.Meta.Currency
-		}
-
-		markets = append(markets, market{
-			marketRequest: marketRequests[i],
-			Price:         result.Meta.RegularMarketPrice,
-			Currency:      currency,
-			PriceHint:     result.Meta.PriceHint,
-			Name: ternary(marketRequests[i].CustomName == "",
-				result.Meta.ShortName,
-				marketRequests[i].CustomName,
-			),
-			PercentChange: percentChange(
-				result.Meta.RegularMarketPrice,
-				previous,
-			),
-			SvgChartPoints: points,
-		})
+		markets = append(markets, market)
 	}
 
 	if len(markets) == 0 {
@@ -232,6 +319,85 @@ func fetchMarketsDataFromYahoo(marketRequests []marketRequest, client *http.Clie
 	}
 
 	return markets, nil
+}
+
+func yahooChartRangeForDays(days int) string {
+	switch {
+	case days <= 21:
+		return "1mo"
+	case days <= 63:
+		return "3mo"
+	case days <= 126:
+		return "6mo"
+	case days <= 252:
+		return "1y"
+	case days <= 504:
+		return "2y"
+	case days <= 1260:
+		return "5y"
+	default:
+		return "max"
+	}
+}
+
+func marketFromYahooResponse(request marketRequest, response marketResponseJson, chartDays int) (market, error) {
+	if chartDays < 2 {
+		chartDays = 2
+	}
+
+	if len(response.Chart.Result) == 0 {
+		return market{}, errors.New("response contains no result")
+	}
+
+	result := &response.Chart.Result[0]
+	if len(result.Indicators.Quote) == 0 {
+		return market{}, errors.New("response contains no quote")
+	}
+
+	prices := result.Indicators.Quote[0].Close
+	if len(prices) == 0 {
+		return market{}, errors.New("response contains no prices")
+	}
+
+	if len(prices) > chartDays {
+		prices = prices[len(prices)-chartDays:]
+	}
+
+	previous := result.Meta.ChartPreviousClose
+	if previous == 0 {
+		previous = result.Meta.RegularMarketPrice
+	}
+
+	// Yahoo can insert null daily bars before the current price, so use the nearest real close.
+	for i := len(prices) - 2; i >= 0; i-- {
+		if prices[i] != 0 {
+			previous = prices[i]
+			break
+		}
+	}
+
+	points := svgPolylineCoordsFromYValues(100, 50, maybeCopySliceWithoutZeroValues(prices))
+
+	currency, exists := currencyToSymbol[strings.ToUpper(result.Meta.Currency)]
+	if !exists {
+		currency = result.Meta.Currency
+	}
+
+	return market{
+		marketRequest: request,
+		Price:         result.Meta.RegularMarketPrice,
+		Currency:      currency,
+		PriceHint:     result.Meta.PriceHint,
+		Name: ternary(request.CustomName == "",
+			result.Meta.ShortName,
+			request.CustomName,
+		),
+		PercentChange: percentChange(
+			result.Meta.RegularMarketPrice,
+			previous,
+		),
+		SvgChartPoints: points,
+	}, nil
 }
 
 var currencyToSymbol = map[string]string{

--- a/internal/dynacat/widget-markets_test.go
+++ b/internal/dynacat/widget-markets_test.go
@@ -1,0 +1,177 @@
+package dynacat
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+type marketTestClient struct {
+	requests     atomic.Int64
+	response     string
+	contextValue string
+}
+
+func (c *marketTestClient) Do(request *http.Request) (*http.Response, error) {
+	c.requests.Add(1)
+	if c.contextValue != "" && request.Context().Value(marketTestContextKey{}) != c.contextValue {
+		panic("expected request context value")
+	}
+
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(c.response)),
+	}, nil
+}
+
+func TestFetchMarketsDataFromYahooDedupesSymbols(t *testing.T) {
+	client := &marketTestClient{response: marketResponseJSON("SPY", "SPDR S&P 500 ETF", []float64{100, 101, 102}), contextValue: "request-context"}
+	ctx := context.WithValue(context.Background(), marketTestContextKey{}, "request-context")
+
+	markets, err := fetchMarketsDataFromYahoo(ctx, []marketRequest{
+		{Symbol: "SPY", CustomName: "First"},
+		{Symbol: "SPY", CustomName: "Second"},
+	}, 21, client)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if client.requests.Load() != 1 {
+		t.Fatalf("Expected 1 request, got %d", client.requests.Load())
+	}
+	if len(markets) != 2 {
+		t.Fatalf("Expected 2 markets, got %d", len(markets))
+	}
+	if markets[0].Name != "First" || markets[1].Name != "Second" {
+		t.Fatalf("Expected duplicate rows to preserve request data, got %#v", markets)
+	}
+}
+
+func TestMarketFromYahooResponseRejectsMissingQuote(t *testing.T) {
+	response := marketResponseFromJSON(t, `{"chart":{"result":[{"meta":{},"indicators":{}}]}}`)
+
+	_, err := marketFromYahooResponse(marketRequest{Symbol: "SPY"}, response, 21)
+	if err == nil {
+		t.Fatal("Expected missing quote error")
+	}
+}
+
+func TestMarketFromYahooResponseTrimsChartDays(t *testing.T) {
+	response := marketResponseFromJSON(t, marketResponseJSON("SPY", "SPDR S&P 500 ETF", []float64{100, 101, 102, 103}))
+
+	market, err := marketFromYahooResponse(marketRequest{Symbol: "SPY"}, response, 2)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if market.SvgChartPoints != "0.00,49.00 100.00,1.00" {
+		t.Fatalf("Expected trimmed chart points, got %q", market.SvgChartPoints)
+	}
+}
+
+func TestMarketFromYahooResponseIgnoresNullPrices(t *testing.T) {
+	response := marketResponseFromJSON(t, `{"chart":{"result":[{"meta":{"currency":"USD","regularMarketPrice":102,"chartPreviousClose":101,"shortName":"SPDR S&P 500 ETF","priceHint":2},"indicators":{"quote":[{"close":[100,null,102]}]}}]}}`)
+
+	market, err := marketFromYahooResponse(marketRequest{Symbol: "SPY"}, response, 21)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if market.SvgChartPoints != "0.00,49.00 100.00,1.00" {
+		t.Fatalf("Expected null price to be ignored, got %q", market.SvgChartPoints)
+	}
+}
+
+func TestMarketFromYahooResponseIgnoresLeadingNullPrices(t *testing.T) {
+	response := marketResponseFromJSON(t, `{"chart":{"result":[{"meta":{"currency":"USD","regularMarketPrice":102,"chartPreviousClose":101,"shortName":"SPDR S&P 500 ETF","priceHint":2},"indicators":{"quote":[{"close":[null,null,100,101,102]}]}}]}}`)
+
+	market, err := marketFromYahooResponse(marketRequest{Symbol: "SPY"}, response, 21)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if market.SvgChartPoints != "0.00,49.00 50.00,25.00 100.00,1.00" {
+		t.Fatalf("Expected leading null prices to be ignored, got %q", market.SvgChartPoints)
+	}
+}
+
+func TestMarketFromYahooResponseKeepsTrailingNullFromShiftingPreviousClose(t *testing.T) {
+	response := marketResponseFromJSON(t, `{"chart":{"result":[{"meta":{"currency":"USD","regularMarketPrice":102,"chartPreviousClose":101,"shortName":"SPDR S&P 500 ETF","priceHint":2},"indicators":{"quote":[{"close":[100,101,null]}]}}]}}`)
+
+	market, err := marketFromYahooResponse(marketRequest{Symbol: "SPY"}, response, 21)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if market.PercentChange != percentChange(102, 101) {
+		t.Fatalf("Expected trailing null not to shift previous close, got %f", market.PercentChange)
+	}
+}
+
+func TestMarketFromYahooResponseSkipsNullGapBeforeCurrentPrice(t *testing.T) {
+	response := marketResponseFromJSON(t, `{"chart":{"result":[{"meta":{"currency":"USD","regularMarketPrice":102,"chartPreviousClose":80,"shortName":"Bitcoin USD","priceHint":2},"indicators":{"quote":[{"close":[80,100,null,102]}]}}]}}`)
+
+	market, err := marketFromYahooResponse(marketRequest{Symbol: "BTC-USD"}, response, 21)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if market.PercentChange != percentChange(102, 100) {
+		t.Fatalf("Expected null gap to be skipped for previous close, got %f", market.PercentChange)
+	}
+}
+
+type marketTestContextKey struct{}
+
+func TestYahooChartRangeForDays(t *testing.T) {
+	tests := []struct {
+		days       int
+		rangeValue string
+	}{
+		{21, "1mo"},
+		{22, "3mo"},
+		{64, "6mo"},
+		{127, "1y"},
+		{253, "2y"},
+		{505, "5y"},
+		{1261, "max"},
+	}
+
+	for _, test := range tests {
+		if value := yahooChartRangeForDays(test.days); value != test.rangeValue {
+			t.Fatalf("Expected %d days to use range %q, got %q", test.days, test.rangeValue, value)
+		}
+	}
+}
+
+func TestSvgPolylineCoordsFromYValuesHandlesFlatValues(t *testing.T) {
+	points := svgPolylineCoordsFromYValues(100, 50, []float64{5, 5, 5})
+
+	if points != "0.00,25.00 50.00,25.00 100.00,25.00" {
+		t.Fatalf("Expected flat line points, got %q", points)
+	}
+}
+
+func marketResponseFromJSON(t *testing.T, data string) marketResponseJson {
+	t.Helper()
+
+	var response marketResponseJson
+	if err := json.NewDecoder(strings.NewReader(data)).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode market response: %v", err)
+	}
+	return response
+}
+
+func marketResponseJSON(symbol string, name string, closes []float64) string {
+	prices := make([]string, 0, len(closes))
+	for i := range closes {
+		prices = append(prices, fmt.Sprintf("%.2f", closes[i]))
+	}
+
+	return `{"chart":{"result":[{"meta":{"currency":"USD","symbol":"` + symbol + `","regularMarketPrice":102,"chartPreviousClose":101,"shortName":"` + name + `","priceHint":2},"indicators":{"quote":[{"close":[` + strings.Join(prices, ",") + `]}]}}]}}`
+}


### PR DESCRIPTION
- Added minimal mode for compact market rows.
- Added configurable chart-days.
- Improved chart parsing for missing/null Yahoo data.
- Fixed flat chart rendering.
- Dedupe symbols and check input data
- Updated markets docs

https://github.com/user-attachments/assets/292b1933-caf4-4ff7-94f2-0daff45d194c

(looks way better on real desktop btw)

---

Testing Needed

- Test normal (nothing broken) and minimal markets widgets when its inline.
- Test different names truncation

Open Question

- Minimal mode currently shows hover info for ticker/price. I’m not sure this belongs there since minimal should stay minimal; we may want to remove it.