### PR TITLE
Do not debounce todo checkbox updates

### DIFF
--- a/internal/dynacat/static/js/todo.js
+++ b/internal/dynacat/static/js/todo.js
@@ -65,7 +65,7 @@ async function saveToServer(id, data) {
     });
 }
 
-function Item(unserialize = {}, onUpdate, onDelete, onEscape, onDragStart) {
+function Item(unserialize = {}, onTextUpdate, onCheckUpdate, onDelete, onEscape, onDragStart) {
     let item, input, inputArea;
 
     const serializeable = {
@@ -80,7 +80,7 @@ function Item(unserialize = {}, onUpdate, onDelete, onEscape, onDragStart) {
             .attrs({ type: "checkbox" })
             .on("change", (e) => {
                 serializeable.checked = e.target.checked;
-                onUpdate();
+                onCheckUpdate();
             })
             .tap(self => self.checked = serializeable.checked),
 
@@ -100,7 +100,7 @@ function Item(unserialize = {}, onUpdate, onDelete, onEscape, onDragStart) {
             })
             .on("input", () => {
                 serializeable.text = inputArea.value;
-                onUpdate();
+                onTextUpdate();
             })
         ).classes("min-width-0", "grow"),
 
@@ -236,15 +236,21 @@ function Todo(id, storageType, collapseAfterConfig) {
         reorderable.component.onDragStart(event, element);
     };
 
+    const serializeItems = () => items.children.map(item => item.component.serialize());
     const saveItems = () => {
         if (isDragging) return;
 
-        const data = items.children.map(item => item.component.serialize());
+        const data = serializeItems();
         if (useServer) {
             saveToServer(id, data);
         } else {
             saveToLocalStorage(id, data);
         }
+    };
+    const renderItems = (data) => {
+        items.replaceChildren(...data.map(d => newItem(d)));
+        inputContainer.classesIf(data.length > 0, "margin-bottom-15");
+        applyCollapsibleState();
     };
 
     const onItemRepositioned = () => saveItems();
@@ -268,6 +274,7 @@ function Todo(id, storageType, collapseAfterConfig) {
     const newItem = (data) => Item(
         data,
         debouncedOnItemUpdate,
+        saveItems,
         onItemDelete,
         () => inputArea.focus(),
         onDragStart
@@ -366,11 +373,7 @@ function Todo(id, storageType, collapseAfterConfig) {
 
     if (useServer) {
         loadFromServer(id).then(data => {
-            items.append(...data.map(d => newItem(d)));
-            if (data.length > 0) {
-                inputContainer.classes("margin-bottom-15");
-            }
-            applyCollapsibleState();
+            renderItems(data);
         });
     }
 


### PR DESCRIPTION
Todo item updates currently use the same debounced save path for both textarea edits and checkbox changes. This makes checkbox state slow (1s to save state), even though checking/unchecking a task is a discrete action.

This changes Todo so only textarea edits remain debounced. Checkbox changes now save immediately, while text input still uses debounce to avoid excessive localStorage writes or server saves when users type quickly.

---

Context

I’m working on a TickTick widget (WIP) and needs several prerequisite commits merged first.
This Todo change is one of those prerequisites. Todo is a useful simple stateful widget for validating shared state behavior because multiple Todo widgets can represent the same list. 

I have a follow-up WIP PR to sync shared Todo state between widgets — and that is super useful to test on same page same widgets but in several variants (full, collapsed, small, inline) without hitting API limits (more info/demo will be in that PR).