### PR TITLE
Add frontend sync of multiple widgets on same page

### DIFF
--- a/internal/dynacat/static/js/page.js
+++ b/internal/dynacat/static/js/page.js
@@ -1148,6 +1148,21 @@ async function setupTodos() {
     }
 }
 
+function setupFrontendWidgetSync() {
+    const widgets = document.querySelectorAll(".widget[data-widget-frontend-sync-key]");
+    const keyCounts = {};
+
+    for (let i = 0; i < widgets.length; i++) {
+        const key = widgets[i].dataset.widgetFrontendSyncKey;
+        keyCounts[key] = (keyCounts[key] || 0) + 1;
+    }
+
+    for (let i = 0; i < widgets.length; i++) {
+        const key = widgets[i].dataset.widgetFrontendSyncKey;
+        if (keyCounts[key] < 2) widgets[i].removeAttribute("data-widget-frontend-sync-key");
+    }
+}
+
 async function setupStopwatches() {
     const elems = document.getElementsByClassName("stopwatch");
     if (elems.length == 0) return;
@@ -1332,6 +1347,7 @@ async function setupPage() {
     pageContentElement.innerHTML = pageContent;
 
     try {
+        setupFrontendWidgetSync();
         setupPopovers();
         setupClocks()
         await setupCalendars();

--- a/internal/dynacat/static/js/todo.js
+++ b/internal/dynacat/static/js/todo.js
@@ -10,11 +10,13 @@ const dragIconSvg = `<svg fill="currentColor" xmlns="http://www.w3.org/2000/svg"
 </svg>`;
 
 export default function(element) {
+    const widget = element.closest(".widget");
     element.swapWith(
         Todo(
             element.dataset.todoId,
             element.dataset.todoStorage,
-            element.dataset.todoCollapseAfter
+            element.dataset.todoCollapseAfter,
+            widget ? widget.dataset.widgetFrontendSyncKey : ""
         )
     )
 }
@@ -176,7 +178,7 @@ function Item(unserialize = {}, onTextUpdate, onCheckUpdate, onDelete, onEscape,
     });
 }
 
-function Todo(id, storageType, collapseAfterConfig) {
+function Todo(id, storageType, collapseAfterConfig, frontendSyncKey) {
     const useServer = storageType === "server";
     const parsedCollapseAfter = collapseAfterConfig === undefined
         ? NaN
@@ -184,11 +186,13 @@ function Todo(id, storageType, collapseAfterConfig) {
     const shouldCollapse = Number.isInteger(parsedCollapseAfter) && parsedCollapseAfter >= 0;
     const collapseAfter = shouldCollapse ? parsedCollapseAfter : 0;
     let items, input, inputArea, inputContainer, lastAddedItem;
+    let todoElement;
     let expandButton, expandButtonTextNode;
     let queuedForRemoval = 0;
     let reorderable;
     let isDragging = false;
     let isExpanded = false;
+    let stateVersion = 0;
 
     const applyCollapsibleState = () => {
         if (!shouldCollapse) {
@@ -237,15 +241,21 @@ function Todo(id, storageType, collapseAfterConfig) {
     };
 
     const serializeItems = () => items.children.map(item => item.component.serialize());
+    const broadcastSync = (data) => {
+        if (!frontendSyncKey) return;
+        window.dispatchEvent(new CustomEvent("dynacat-widget-sync", { detail: { frontendSyncKey, source: todoElement, data } }));
+    };
     const saveItems = () => {
         if (isDragging) return;
 
+        stateVersion++;
         const data = serializeItems();
         if (useServer) {
             saveToServer(id, data);
         } else {
             saveToLocalStorage(id, data);
         }
+        broadcastSync(data);
     };
     const renderItems = (data) => {
         items.replaceChildren(...data.map(d => newItem(d)));
@@ -344,7 +354,7 @@ function Todo(id, storageType, collapseAfterConfig) {
             });
     }
 
-    const todoElement = fragment().append(
+    todoElement = fragment().append(
         inputContainer = elem()
             .classes("todo-input", "flex", "gap-10", "items-center")
             .classesIf(items.children.length > 0, "margin-bottom-15")
@@ -371,8 +381,18 @@ function Todo(id, storageType, collapseAfterConfig) {
 
     applyCollapsibleState();
 
+    if (frontendSyncKey) {
+        window.addEventListener("dynacat-widget-sync", (event) => {
+            if (event.detail.frontendSyncKey !== frontendSyncKey || event.detail.source === todoElement) return;
+            stateVersion++;
+            renderItems(event.detail.data);
+        });
+    }
+
     if (useServer) {
+        const loadVersion = stateVersion;
         loadFromServer(id).then(data => {
+            if (stateVersion !== loadVersion) return;
             renderItems(data);
         });
     }

--- a/internal/dynacat/templates/widget-base.html
+++ b/internal/dynacat/templates/widget-base.html
@@ -1,5 +1,6 @@
 <div class="widget widget-type-{{ .GetType }}{{ if .CSSClass }} {{ .CSSClass }}{{ end }}"
      data-widget-id="{{ .GetID }}"
+     {{ if .GetFrontendSyncKey }}data-widget-frontend-sync-key="{{ .GetFrontendSyncKey }}"{{ end }}
      {{ if and .UpdateInterval (.IsDynamicUpdateEnabled) }}
      data-update-interval="{{ .UpdateInterval.Milliseconds }}"
      {{ end }}

--- a/internal/dynacat/widget-result-cache.go
+++ b/internal/dynacat/widget-result-cache.go
@@ -1,0 +1,114 @@
+package dynacat
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// widgetResultCache shares identical widget API results across widget instances
+// while using each widget's existing cache policy as the result TTL.
+
+const widgetResultErrorCacheDuration = time.Second
+
+type widgetResultCache[T any] struct {
+	mu         sync.Mutex
+	generation uint64
+	items      map[string]*widgetResultCacheEntry[T]
+}
+
+type widgetResultCacheEntry[T any] struct {
+	value      T
+	err        error
+	expires    time.Time
+	ready      chan struct{}
+	generation uint64
+}
+
+func newWidgetResultCache[T any]() *widgetResultCache[T] {
+	return &widgetResultCache[T]{items: make(map[string]*widgetResultCacheEntry[T])}
+}
+
+func (cache *widgetResultCache[T]) GetForWidget(ctx context.Context, widget *widgetBase, key string, fetch func(context.Context) (T, error)) (T, error) {
+	return cache.get(ctx, key, widget.resultCacheDuration(), widgetResultErrorCacheDuration, fetch)
+}
+
+func (cache *widgetResultCache[T]) Clear() {
+	cache.mu.Lock()
+	cache.generation++
+	cache.items = make(map[string]*widgetResultCacheEntry[T])
+	cache.mu.Unlock()
+}
+
+func (cache *widgetResultCache[T]) get(ctx context.Context, key string, ttl time.Duration, errorTTL time.Duration, fetch func(context.Context) (T, error)) (T, error) {
+	for {
+		now := time.Now()
+
+		cache.mu.Lock()
+		entry := cache.items[key]
+		if entry != nil {
+			if entry.ready == nil && now.Before(entry.expires) {
+				value, err := entry.value, entry.err
+				cache.mu.Unlock()
+				return value, err
+			}
+
+			if entry.ready != nil {
+				ready := entry.ready
+				cache.mu.Unlock()
+
+				select {
+				case <-ready:
+				case <-ctx.Done():
+					var zero T
+					return zero, ctx.Err()
+				}
+
+				cache.mu.Lock()
+				if entry.generation != cache.generation {
+					cache.mu.Unlock()
+					continue
+				}
+				value, err := entry.value, entry.err
+				cache.mu.Unlock()
+				return value, err
+			}
+		}
+
+		entry = &widgetResultCacheEntry[T]{ready: make(chan struct{}), generation: cache.generation}
+		cache.items[key] = entry
+		cache.mu.Unlock()
+
+		value, err := fetch(ctx)
+
+		cache.mu.Lock()
+		if entry.generation != cache.generation {
+			close(entry.ready)
+			entry.ready = nil
+			cache.mu.Unlock()
+			continue
+		}
+
+		entry.value = value
+		entry.err = err
+		if err != nil {
+			entry.expires = time.Now().Add(errorTTL)
+		} else {
+			entry.expires = time.Now().Add(ttl)
+		}
+		close(entry.ready)
+		entry.ready = nil
+		cache.mu.Unlock()
+
+		return value, err
+	}
+}
+
+func (w *widgetBase) resultCacheDuration() time.Duration {
+	duration := time.Until(w.getNextUpdateTime())
+	if duration < 0 {
+		return 0
+	}
+
+	return duration
+}

--- a/internal/dynacat/widget-result-cache_test.go
+++ b/internal/dynacat/widget-result-cache_test.go
@@ -1,0 +1,199 @@
+package dynacat
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestWidgetResultCacheSharesSameWeatherRequestAcrossWidgets(t *testing.T) {
+	cache := newWidgetResultCache[*weather]()
+	firstWidget := &weatherWidget{Location: "London, United Kingdom", Units: "metric"}
+	secondWidget := &weatherWidget{Location: "London, United Kingdom", Units: "metric"}
+	if err := firstWidget.initialize(); err != nil {
+		t.Fatal(err)
+	}
+	if err := secondWidget.initialize(); err != nil {
+		t.Fatal(err)
+	}
+	calls := 0
+	fetchLondonWeather := func(context.Context) (*weather, error) {
+		calls++
+		return &weather{
+			Temperature:         21,
+			ApparentTemperature: 19,
+			WeatherCode:         2,
+			Columns: []weatherColumn{
+				{Temperature: 18, Scale: 0.4},
+				{Temperature: 21, Scale: 0.7},
+				{Temperature: 16, Scale: 0.2, HasPrecipitation: true},
+			},
+		}, nil
+	}
+
+	key := "weather|" + firstWidget.Location + "|" + firstWidget.Units
+	weather, err := cache.GetForWidget(context.Background(), &firstWidget.widgetBase, key, fetchLondonWeather)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstWidget.Weather = weather
+
+	weather, err = cache.GetForWidget(context.Background(), &secondWidget.widgetBase, key, fetchLondonWeather)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondWidget.Weather = weather
+
+	if firstWidget.Weather != secondWidget.Weather || secondWidget.Weather.Temperature != 21 || calls != 1 {
+		t.Fatalf("got same_result=%t temp=%d calls=%d", firstWidget.Weather == secondWidget.Weather, secondWidget.Weather.Temperature, calls)
+	}
+}
+
+func TestWidgetResultCacheCoalescesConcurrentSameRepositoryReleaseWidgets(t *testing.T) {
+	cache := newWidgetResultCache[appReleaseList]()
+	widgets := []*releasesWidget{
+		{Repositories: []*releaseRequest{{Repository: "Panonim/dynacat", source: releaseSourceGithub}}},
+		{Repositories: []*releaseRequest{{Repository: "Panonim/dynacat", source: releaseSourceGithub}}},
+	}
+	for _, widget := range widgets {
+		if err := widget.initialize(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	fetchDynacatReleases := func(context.Context) (appReleaseList, error) {
+		if calls.Add(1) == 1 {
+			close(started)
+		}
+		<-release
+		return appReleaseList{
+			{
+				Source:       releaseSourceGithub,
+				Name:         "Panonim/dynacat",
+				Version:      "v1.2.3",
+				NotesUrl:     "https://github.com/Panonim/dynacat/releases/tag/v1.2.3",
+				TimeReleased: time.Unix(1710000000, 0),
+			},
+		}, nil
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, len(widgets))
+	key := "releases|github|Panonim/dynacat|include-prereleases=false"
+	for i, widget := range widgets {
+		wg.Add(1)
+		go func(widget *releasesWidget) {
+			defer wg.Done()
+			result, err := cache.GetForWidget(context.Background(), &widget.widgetBase, key, fetchDynacatReleases)
+			if err != nil {
+				errs <- err
+				return
+			}
+			widget.Releases = result
+			errs <- nil
+		}(widget)
+
+		if i == 0 {
+			<-started
+		}
+	}
+
+	close(release)
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if calls.Load() != 1 {
+		t.Fatalf("fetch called %d times", calls.Load())
+	}
+
+	for _, widget := range widgets {
+		if len(widget.Releases) != 1 || widget.Releases[0].Version != "v1.2.3" {
+			t.Fatalf("got %#v", widget.Releases)
+		}
+	}
+}
+
+func TestWidgetResultCacheClearRefetchesTodoListAfterSave(t *testing.T) {
+	cache := newWidgetResultCache[[]todoTask]()
+	widget := &todoWidget{TodoID: "deploy", Storage: "server"}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	fetchTasks := func(context.Context) ([]todoTask, error) {
+		call := calls.Add(1)
+		if call == 1 {
+			close(started)
+			<-release
+		}
+
+		if call == 1 {
+			return []todoTask{{Text: "deploy", Checked: false}}, nil
+		}
+
+		return []todoTask{{Text: "deploy", Checked: true}}, nil
+	}
+
+	firstDone := make(chan struct{})
+	firstResult := make(chan []todoTask, 1)
+	go func() {
+		defer close(firstDone)
+		result, err := cache.GetForWidget(context.Background(), &widget.widgetBase, "to-do|"+widget.Storage+"|"+widget.TodoID, fetchTasks)
+		if err != nil {
+			t.Errorf("Get returned error: %v", err)
+			return
+		}
+		firstResult <- result
+	}()
+
+	<-started
+	cache.Clear()
+	close(release)
+	<-firstDone
+	close(firstResult)
+
+	for result := range firstResult {
+		if len(result) != 1 || !result[0].Checked {
+			t.Fatalf("got stale in-flight tasks %#v", result)
+		}
+	}
+
+	if calls.Load() != 2 {
+		t.Fatalf("fetch called %d times", calls.Load())
+	}
+}
+
+func TestWidgetResultCacheCachesWeatherErrorsForErrorTTL(t *testing.T) {
+	cache := newWidgetResultCache[*weather]()
+	widget := &weatherWidget{Location: "Paris, France", Units: "metric"}
+	if err := widget.initialize(); err != nil {
+		t.Fatal(err)
+	}
+	expectedErr := errors.New("open-meteo rate limited")
+	calls := 0
+	fetchWeather := func(context.Context) (*weather, error) {
+		calls++
+		return nil, expectedErr
+	}
+
+	for i := 0; i < 2; i++ {
+		_, err := cache.GetForWidget(context.Background(), &widget.widgetBase, "weather|"+widget.Location+"|"+widget.Units, fetchWeather)
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("got error %v", err)
+		}
+	}
+
+	if calls != 1 {
+		t.Fatalf("fetch called %d times", calls)
+	}
+}

--- a/internal/dynacat/widget-todo.go
+++ b/internal/dynacat/widget-todo.go
@@ -8,18 +8,20 @@ import (
 var todoWidgetTemplate = mustParseTemplate("todo.html", "widget-base.html")
 
 type todoWidget struct {
-	widgetBase `yaml:",inline"`
-	Frameless  bool          `yaml:"frameless"`
-	cachedHTML template.HTML `yaml:"-"`
-	TodoID     string        `yaml:"id"`
-	Storage    string        `yaml:"storage"`
-	CollapseAfter *int       `yaml:"collapse-after"`
+	widgetBase    `yaml:",inline"`
+	Frameless     bool          `yaml:"frameless"`
+	cachedHTML    template.HTML `yaml:"-"`
+	TodoID        string        `yaml:"id"`
+	Storage       string        `yaml:"storage"`
+	CollapseAfter *int          `yaml:"collapse-after"`
 }
 
 func (widget *todoWidget) initialize() error {
 	widget.withTitle("To-do").withError(nil)
 
-	if widget.Storage != "" && widget.Storage != "local" && widget.Storage != "server" {
+	if widget.Storage == "" {
+		widget.Storage = "local"
+	} else if widget.Storage != "local" && widget.Storage != "server" {
 		return fmt.Errorf("storage must be either \"local\" or \"server\", got %q", widget.Storage)
 	}
 
@@ -31,6 +33,7 @@ func (widget *todoWidget) initialize() error {
 		return fmt.Errorf("collapse-after must be -1 or greater, got %d", *widget.CollapseAfter)
 	}
 
+	widget.frontendSyncKey = "to-do|" + widget.Storage + "|" + widget.TodoID
 	widget.cachedHTML = widget.renderTemplate(widget, todoWidgetTemplate)
 	return nil
 }

--- a/internal/dynacat/widget.go
+++ b/internal/dynacat/widget.go
@@ -181,6 +181,7 @@ type widgetBase struct {
 	cacheType           cacheType            `yaml:"-"`
 	nextUpdate          time.Time            `yaml:"-"`
 	updateRetriedTimes  int                  `yaml:"-"`
+	frontendSyncKey     string               `yaml:"-"`
 }
 
 type widgetProviders struct {
@@ -254,6 +255,14 @@ func (w *widgetBase) update(ctx context.Context) {
 
 func (w *widgetBase) GetID() uint64 {
 	return w.ID
+}
+
+func (w *widgetBase) GetFrontendSyncKey() string {
+	if w.frontendSyncKey == "" {
+		return ""
+	}
+
+	return hashString(w.frontendSyncKey)[:12]
 }
 
 func (w *widgetBase) setID(id uint64) {


### PR DESCRIPTION
Introduce a frontend widget sync key, which will allow equal content widgets to sync and have less queries to backend. **Works not only with external API queries, but with local browser widgets**, too:

https://github.com/user-attachments/assets/7d20acc9-582f-4529-a9a5-44079c3bde92

Change is not actually very useful in real world (not many cases, when same widgets are on same page of casual user), but it is very useful when locally testing some widget stylings or having a demo video. Also it helps not to have many API queries in those situtations for the same widget, — and it is already helping me to develop TickTick widget, which has its API limits.

There is no good solution currently in project to this problem due to project architecture decisions made earlier. Making this backend-only is not enough - some widgets like `todo` may be local only. Though I considered it and had a working prototype, which is deleted. Same reason for syncing based on network data caching.

This PR splitted on three commits:

86a615e5e98e139b071053dda9143d3fa138ae33 is already enough to make feature work for frontend-only widgets like `todo` one.

0daa5988b38716fc841ae1352fc40316cd8350fa - this code prevents some unneeded bytes to be on page, I mean the `widget-frontend-sync-key` divs, when there are no such cases like 2+ equal widgets on the page. Just a perfectionist little touch.

262da6a68f97cf0f5a8c737d8aeeb98ee0ff74be - adds shared widget result cache infrastructure. It uses existing widget cache policy as result TTL and coalesces same-key backend fetches across widget instances. This is added for the upcoming TickTick widget work; TickTick will use only `ticktickTasksCache.GetForWidget(...)` from this code.

`widget.frontendSyncKey` needs all the params, that are not binded to the presentation layer (like frameless/collapse-after/...). There is no easy way to take them from all widgets, no such method now. In case of todo widget it is widget id and the storage - todo widgets with `local` storage would not be synced with sqlitedb storage.