### PR TITLE
Fix docker image name : At least some version of docker only allow lowercase only image names.

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -66,7 +66,7 @@ Alternatively, you can load the contents of a file who's path is provided by an 
 ```yaml
 services:
   dynacat:
-    image: Panonim/dynacat
+    image: panonim/dynacat
     environment:
       - TOKEN_FILE=/home/user/token
     volumes:
@@ -1360,7 +1360,7 @@ Display the status of your Docker containers along with an icon and an optional 
 > ```yaml
 > services:
 >   dynacat:
->     image: Panonim/dynacat
+>     image: panonim/dynacat
 >     volumes:
 >       - /var/run/docker.sock:/var/run/docker.sock
 > ```
@@ -1541,7 +1541,7 @@ Example:
 > ```yaml
 > services:
 >   dynacat:
->     image: Panonim/dynacat
+>     image: panonim/dynacat
 >     volumes:
 >       - /var/run/docker.sock:/var/run/docker.sock
 > ```
@@ -2257,7 +2257,7 @@ You can also specify the value for this token through an ENV variable using the 
 ```yaml
 services:
   dynacat:
-    image: Panonim/dynacat
+    image: panonim/dynacat
     environment:
       - GITHUB_TOKEN=<your token>
 ```
@@ -2811,7 +2811,7 @@ Just like the `group` widget, you can insert any widget type, you can even inser
 
 ### Stopwatch
 
-A browser-based stopwatch widget. 
+A browser-based stopwatch widget.
 
 Example:
 

--- a/docs/docs/docker-options.md
+++ b/docs/docs/docker-options.md
@@ -115,7 +115,7 @@ Add the following to your `docker-compose.yml`:
 ```yaml
 services:
   dynacat:
-    image: Panonim/dynacat:latest
+    image: panonim/dynacat:latest
     devices:
       - /dev/zfs:/dev/zfs
     cap_drop:


### PR DESCRIPTION
Fix docker image name in docs : At least some version of docker only allow lowercase only image names for docker.io

```bash
$ docker pull Panonim/dynacat
Using default tag: latest
Error response from daemon: failed to resolve reference "Panonim/dynacat:latest": failed to do request: Head "https://Panonim/v2/dynacat/manifests/latest": dial tcp: lookup Panonim: Temporary failure in name resolution
```

```bash
$ docker pull panonim/dynacat
Using default tag: latest
latest: Pulling from panonim/dynacat
Digest: sha256:9cf96395fd2119c156bef606fa368878db2a9c90815b8b82995743468c10ed85
Status: Image is up to date for panonim/dynacat:latest
docker.io/panonim/dynacat:latest
```

```bash
$ docker pull docker.io/Panonim/dynacat
invalid reference format: repository name (Panonim/dynacat) must be lowercase
```

```bash
$ docker pull docker.io/panonim/dynacat
Using default tag: latest
latest: Pulling from panonim/dynacat
Digest: sha256:9cf96395fd2119c156bef606fa368878db2a9c90815b8b82995743468c10ed85
Status: Image is up to date for panonim/dynacat:latest
docker.io/panonim/dynacat:latest
```

Of course, the same behaviour exists with docker-compose.

I've tried to only change "Panonim/dynacat" to "panonim/dynacat" when (and only when) it references a `docker.io` image, and not when it's references a `github.com` image
