### PR TITLE
Market widget: fix incorrect daily percentage when Yahoo returns incomplete candle data

### DIFF
--- a/internal/dynacat/widget-markets.go
+++ b/internal/dynacat/widget-markets.go
@@ -134,6 +134,7 @@ type marketResponseJson struct {
 				Currency           string  `json:"currency"`
 				Symbol             string  `json:"symbol"`
 				RegularMarketPrice float64 `json:"regularMarketPrice"`
+				PreviousClose      float64 `json:"previousClose"`
 				ChartPreviousClose float64 `json:"chartPreviousClose"`
 				ShortName          string  `json:"shortName"`
 				PriceHint          int     `json:"priceHint"`
@@ -195,8 +196,15 @@ func fetchMarketsDataFromYahoo(marketRequests []marketRequest, client *http.Clie
 			previous = result.Meta.RegularMarketPrice
 		}
 
-		if len(prices) >= 2 && prices[len(prices)-2] != 0 {
-			previous = prices[len(prices)-2]
+		if result.Meta.PreviousClose != 0 {
+			previous = result.Meta.PreviousClose
+		} else {
+			for i := len(prices) - 2; i >= 0; i-- {
+				if prices[i] != 0 {
+					previous = prices[i]
+					break
+				}
+			}
 		}
 
 		points := svgPolylineCoordsFromYValues(100, 50, maybeCopySliceWithoutZeroValues(prices))


### PR DESCRIPTION
Fixes incorrect daily percentage changes in the markets widget when Yahoo returns incomplete candle data.

The widget calculated change from the previous daily close. If Yahoo returned a 0 placeholder as the previous candle, the code fell back to chartPreviousClose. That field can be stale or represent the chart range baseline instead of the actual previous close.

Example: BTC-USD returned a current price around $64k, a 0 previous candle, and chartPreviousClose around $81k (due to we quering month daterange in markets widgets, this price is month ago), causing the widget to show about -20%.

before

<img width="598" height="136" alt="CleanShot 2026-06-14 at 09 59 36@2x" src="https://github.com/user-attachments/assets/3ba38d25-5bb8-4ba4-8b73-be7a46f019af" />

after

<img width="636" height="136" alt="CleanShot 2026-06-14 at 10 00 02@2x" src="https://github.com/user-attachments/assets/ede02063-01b5-4f6d-8e0d-677e47d0a452" />

The fix scans backward through the close series for the latest non-zero close before falling back to Yahoo metadata.