### PR TITLE
Youtube: add popover text tooltips to video titles if they are truncated

### DIFF
--- a/internal/dynacat/static/js/popover.js
+++ b/internal/dynacat/static/js/popover.js
@@ -64,6 +64,11 @@ function showPopover() {
     activeTarget = pendingTarget;
     pendingTarget = null;
 
+    if (activeTarget.dataset.popoverIfTruncated !== undefined && !isElementTruncated(activeTarget)) {
+        activeTarget = null;
+        return;
+    }
+
     const popoverType = activeTarget.dataset.popoverType;
 
     if (popoverType === "text") {
@@ -182,6 +187,10 @@ function handleHidePopoverOnEscape(event) {
     if (event.key === "Escape") {
         hidePopover();
     }
+}
+
+function isElementTruncated(element) {
+    return element.scrollWidth > element.clientWidth || element.scrollHeight > element.clientHeight;
 }
 
 export function setupPopovers() {

--- a/internal/dynacat/templates/video-card-contents.html
+++ b/internal/dynacat/templates/video-card-contents.html
@@ -3,7 +3,7 @@
     <img class="video-thumbnail thumbnail" loading="lazy" src="{{ .ThumbnailUrl }}" alt="">
 </a>
 <div class="margin-top-10 margin-bottom-widget flex flex-column grow padding-inline-widget">
-    <a class="text-truncate-2-lines margin-bottom-auto color-primary-if-not-visited" href="{{ .Url | safeURL }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
+    <a class="text-truncate-2-lines margin-bottom-auto color-primary-if-not-visited" href="{{ .Url | safeURL }}" target="_blank" rel="noreferrer" title="" data-popover-type="text" data-popover-position="below" data-popover-if-truncated data-popover-text="{{ .Title }}">{{ .Title }}</a>
     <ul class="list-horizontal-text flex-nowrap margin-top-7">
         <li class="shrink-0" {{ dynamicRelativeTimeAttrs .TimePosted }}></li>
         <li class="min-width-0">

--- a/internal/dynacat/templates/videos-vertical-list.html
+++ b/internal/dynacat/templates/videos-vertical-list.html
@@ -8,7 +8,7 @@
     <li class="flex thumbnail-parent gap-10 items-center">
         <img class="video-horizontal-list-thumbnail thumbnail" loading="lazy" src="{{ .ThumbnailUrl }}" alt="">
         <div class="min-width-0">
-            <a class="block text-truncate color-primary-if-not-visited" href="{{ .Url | safeURL }}" target="_blank" rel="noreferrer">{{ .Title }}</a>
+            <a class="block text-truncate color-primary-if-not-visited" href="{{ .Url | safeURL }}" target="_blank" rel="noreferrer" title="" data-popover-type="text" data-popover-position="below" data-popover-if-truncated data-popover-text="{{ .Title }}">{{ .Title }}</a>
             <ul class="list-horizontal-text flex-nowrap">
                 <li class="shrink-0" {{ dynamicRelativeTimeAttrs .TimePosted }}></li>
                 <li class="min-width-0">


### PR DESCRIPTION
Videos I like almost always have long title that is truncated with `...`. I am forced to hover the title to see untruncated versions.

I've decided to enhance UX:

1) native title in browser takes too much time to show, too much ms. It also doesn't feel dynacat like. Lets use popovers we already have in other widgets.

<img width="704" height="568" alt="CleanShot 2026-06-14 at 12 02 11@2x" src="https://github.com/user-attachments/assets/c7833af9-2e4f-4a63-a628-0e23666396da" />

2) I think there is no need to render the title/popover and duplicate information if video title is not truncated