### PR TITLE
Preserve the intended destination through login

### DIFF
--- a/internal/dynacat/auth.go
+++ b/internal/dynacat/auth.go
@@ -14,6 +14,7 @@ import (
 	mathrand "math/rand/v2"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/bcrypt"
@@ -247,7 +248,10 @@ func (a *application) handleAuthenticationAttempt(w http.ResponseWriter, r *http
 	delete(a.failedAuthAttempts, ip)
 	a.authAttemptsMu.Unlock()
 
+	redirect := a.takeLoginRedirect(w, r)
+	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{"redirect": redirect})
 }
 
 func (a *application) getAuthenticatedUser(w http.ResponseWriter, r *http.Request) *authenticatedUser {
@@ -359,7 +363,7 @@ func (a *application) handleAccessControl(w http.ResponseWriter, r *http.Request
 	if user == nil {
 		switch fallback {
 		case redirectToLogin:
-			http.Redirect(w, r, a.Config.Server.BaseURL+"/login", http.StatusSeeOther)
+			a.redirectToLoginPage(w, r)
 		case showUnauthorizedJSON:
 			w.WriteHeader(http.StatusUnauthorized)
 			w.Write([]byte(`{"error": "Unauthorized"}`))
@@ -375,7 +379,7 @@ func (a *application) handleAccessControl(w http.ResponseWriter, r *http.Request
 
 	switch fallback {
 	case redirectToLogin:
-		http.Redirect(w, r, a.Config.Server.BaseURL+"/login", http.StatusSeeOther)
+		a.redirectToLoginPage(w, r)
 	case showUnauthorizedJSON:
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(`{"error": "Unauthorized"}`))
@@ -399,6 +403,52 @@ func (a *application) handleUnauthorizedResponse(w http.ResponseWriter, r *http.
 	}
 
 	return true
+}
+
+const AUTH_REDIRECT_COOKIE_NAME = "dynacat_redirect"
+
+// isSafeLocalPath reports whether target is a same-origin path safe to use in a
+// redirect: it must be root-relative and must not be a protocol-relative
+// ("//host") or backslash ("/\host") URL a browser could resolve elsewhere.
+func isSafeLocalPath(target string) bool {
+	return strings.HasPrefix(target, "/") &&
+		!strings.HasPrefix(target, "//") &&
+		!strings.HasPrefix(target, "/\\")
+}
+
+// redirectToLoginPage remembers where an unauthenticated visitor was headed
+// (path and query) so they can be returned there after logging in, then sends
+// them to the login page.
+func (a *application) redirectToLoginPage(w http.ResponseWriter, r *http.Request) {
+	if target := r.URL.RequestURI(); isSafeLocalPath(target) {
+		http.SetCookie(w, &http.Cookie{
+			Name:     AUTH_REDIRECT_COOKIE_NAME,
+			Value:    target,
+			Expires:  time.Now().Add(OIDC_STATE_VALID_PERIOD),
+			Secure:   a.isRequestHTTPS(r),
+			Path:     a.Config.Server.BaseURL + "/",
+			SameSite: http.SameSiteLaxMode,
+			HttpOnly: true,
+		})
+	}
+	http.Redirect(w, r, a.Config.Server.BaseURL+"/login", http.StatusSeeOther)
+}
+
+// takeLoginRedirect consumes and clears the post-login redirect cookie,
+// returning a safe destination to send the user to after a successful login.
+func (a *application) takeLoginRedirect(w http.ResponseWriter, r *http.Request) string {
+	target := a.Config.Server.BaseURL + "/"
+	if c, err := r.Cookie(AUTH_REDIRECT_COOKIE_NAME); err == nil && isSafeLocalPath(c.Value) {
+		target = c.Value
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     AUTH_REDIRECT_COOKIE_NAME,
+		Value:    "",
+		Expires:  time.Now().Add(-1 * time.Hour),
+		Path:     a.Config.Server.BaseURL + "/",
+		HttpOnly: true,
+	})
+	return target
 }
 
 func (a *application) AnyAuthEnabled() bool {

--- a/internal/dynacat/auth_oidc.go
+++ b/internal/dynacat/auth_oidc.go
@@ -233,7 +233,7 @@ func (a *application) handleOIDCCallback(w http.ResponseWriter, r *http.Request)
 	})
 
 	slog.Info("OIDC user logged in", "username", username)
-	http.Redirect(w, r, baseURL+"/", http.StatusSeeOther)
+	http.Redirect(w, r, a.takeLoginRedirect(w, r), http.StatusSeeOther)
 }
 
 func extractGroupsClaim(claims map[string]interface{}, claimName string) []string {

--- a/internal/dynacat/auth_redirect_test.go
+++ b/internal/dynacat/auth_redirect_test.go
@@ -1,0 +1,73 @@
+package dynacat
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsSafeLocalPath(t *testing.T) {
+	cases := map[string]bool{
+		"/":                    true,
+		"/?code=123":           true,
+		"/page?x=y&z=1":        true,
+		"/dynacat/?code=abc":   true,
+		"":                     false,
+		"//evil.com":           false,
+		"/\\evil.com":          false,
+		"https://evil.com":     false,
+		"http://evil.com/path": false,
+		"javascript:alert(1)":  false,
+		"evil.com":             false,
+	}
+	for in, want := range cases {
+		if got := isSafeLocalPath(in); got != want {
+			t.Errorf("isSafeLocalPath(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func findCookie(cookies []*http.Cookie, name string) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == name {
+			return c
+		}
+	}
+	return nil
+}
+
+func TestLoginRedirectRoundTrip(t *testing.T) {
+	app := &application{} // BaseURL = "", HTTPS = false
+
+	// Bouncing an unauthenticated request remembers the original path+query.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/secret?code=123", nil)
+	app.redirectToLoginPage(rec, req)
+
+	if loc := rec.Result().Header.Get("Location"); loc != "/login" {
+		t.Errorf("Location = %q, want /login", loc)
+	}
+	saved := findCookie(rec.Result().Cookies(), AUTH_REDIRECT_COOKIE_NAME)
+	if saved == nil || saved.Value != "/secret?code=123" {
+		t.Fatalf("redirect cookie = %v, want value /secret?code=123", saved)
+	}
+
+	// On a later request the destination is returned and the cookie is cleared.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/api/oidc/callback", nil)
+	req2.AddCookie(saved)
+	if got := app.takeLoginRedirect(rec2, req2); got != "/secret?code=123" {
+		t.Errorf("takeLoginRedirect = %q, want /secret?code=123", got)
+	}
+	if cleared := findCookie(rec2.Result().Cookies(), AUTH_REDIRECT_COOKIE_NAME); cleared == nil || cleared.Value != "" {
+		t.Errorf("expected redirect cookie to be cleared, got %v", cleared)
+	}
+
+	// A tampered, off-origin cookie value is ignored in favor of the safe default.
+	rec3 := httptest.NewRecorder()
+	req3 := httptest.NewRequest(http.MethodGet, "/api/oidc/callback", nil)
+	req3.AddCookie(&http.Cookie{Name: AUTH_REDIRECT_COOKIE_NAME, Value: "//evil.com"})
+	if got := app.takeLoginRedirect(rec3, req3); got != "/" {
+		t.Errorf("takeLoginRedirect with off-origin value = %q, want /", got)
+	}
+}

--- a/internal/dynacat/static/js/login.js
+++ b/internal/dynacat/static/js/login.js
@@ -118,7 +118,7 @@ if (usernameInput && passwordInput && loginButton) {
             let destination = pageData.baseURL + "/";
             try {
                 const data = await response.json();
-                if (data && typeof data.redirect === "string" && data.redirect.startsWith("/")) {
+                if (data && typeof data.redirect === "string" && data.redirect.startsWith("/") && !data.redirect.startsWith("//")) {
                     destination = data.redirect;
                 }
             } catch (_) { /* no body; fall back to home */ }

--- a/internal/dynacat/static/js/login.js
+++ b/internal/dynacat/static/js/login.js
@@ -115,7 +115,14 @@ if (usernameInput && passwordInput && loginButton) {
 
         state.isLoading = false;
         if (response.status === 200) {
-            setTimeout(() => { window.location.href = pageData.baseURL + "/"; }, 300);
+            let destination = pageData.baseURL + "/";
+            try {
+                const data = await response.json();
+                if (data && typeof data.redirect === "string" && data.redirect.startsWith("/")) {
+                    destination = data.redirect;
+                }
+            } catch (_) { /* no body; fall back to home */ }
+            setTimeout(() => { window.location.href = destination; }, 300);
 
             container.animate({
                 keyframes: [{ offset: 1, transform: "scale(0.95)", opacity: 0 }],


### PR DESCRIPTION
## Summary

An unauthenticated visitor who opens a deep link is sent to `/login`, but the original URL is lost along the way, so they always land back on `/` after authenticating. That drops any query string, including a `?code=` parameter or a link to a specific page.

This remembers where the visitor was headed and returns them there after login.

## Changes

- When `handleAccessControl` bounces an unauthenticated page request to `/login`, it stores the original `RequestURI` (path + query) in a short-lived cookie: HttpOnly, `SameSite=Lax` (so it survives the OIDC round-trip, like the existing `oidc_state` cookie), `Secure` on HTTPS, ~5 minute expiry (the same `OIDC_STATE_VALID_PERIOD` the OIDC flow cookies use).
- The OIDC callback and the password login both read that cookie and redirect there instead of `/`, then clear it.
- Password login previously returned a bare `200` and the JS navigated to `/`; it now returns the destination as JSON and `login.js` uses it.

## Security

The stored value is only honored when it is a same-origin path (must start with a single `/`, rejecting `//host`, `/\host`, and anything with a scheme or host), so it cannot be turned into an open redirect. It is also always a path the visitor already requested on this server. Covered by tests.

## Testing

- `go build ./...` and `go vet` are clean.
- New `auth_redirect_test.go` covers the path guard (including `//evil.com`, `/\evil.com`, absolute and `javascript:` URLs) and the full remember/restore/clear round-trip, including a tampered off-origin cookie value falling back to `/`.
