### PR TITLE
Twitch: setting to open stream instead of category if click on category

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -3056,6 +3056,7 @@ Preview:
 | channels | array | yes | |
 | collapse-after | integer | no | 5 |
 | sort-by | string | no | viewers |
+| link-category-to-stream | boolean | no | false |
 
 ##### `channels`
 A list of channels to display.
@@ -3065,6 +3066,9 @@ How many channels are visible before the "SHOW MORE" button appears. Set to `-1`
 
 ##### `sort-by`
 Can be used to specify the order in which the channels are displayed. Possible values are `viewers` and `live`.
+
+##### `link-category-to-stream`
+When set to `true`, clicking a live channel's game name opens the streamer instead of the Twitch game category.
 
 ### Twitch Top Games
 Display a list of games with the most viewers on Twitch.

--- a/internal/dynacat/templates/twitch-channels.html
+++ b/internal/dynacat/templates/twitch-channels.html
@@ -29,7 +29,7 @@
                 {{ if .Exists }}
                     {{ if .IsLive }}
                         {{ if .Category }}
-                            <a class="text-truncate block" href="https://www.twitch.tv/directory/category/{{ .CategorySlug }}" target="_blank" rel="noreferrer">{{ .Category }}</a>
+                            <a class="text-truncate block" href="{{ if $.LinkCategoryToStream }}https://twitch.tv/{{ .Login }}{{ else }}https://www.twitch.tv/directory/category/{{ .CategorySlug }}{{ end }}" target="_blank" rel="noreferrer">{{ .Category }}</a>
                         {{ end }}
                     <ul class="list-horizontal-text">
                         <li {{ dynamicRelativeTimeAttrs .LiveSince }}></li>

--- a/internal/dynacat/widget-twitch-channels.go
+++ b/internal/dynacat/widget-twitch-channels.go
@@ -13,12 +13,13 @@ import (
 var twitchChannelsWidgetTemplate = mustParseTemplate("twitch-channels.html", "widget-base.html")
 
 type twitchChannelsWidget struct {
-	widgetBase      `yaml:",inline"`
-	Frameless       bool            `yaml:"frameless"`
-	ChannelsRequest []string        `yaml:"channels"`
-	Channels        []twitchChannel `yaml:"-"`
-	CollapseAfter   int             `yaml:"collapse-after"`
-	SortBy          string          `yaml:"sort-by"`
+	widgetBase           `yaml:",inline"`
+	Frameless            bool            `yaml:"frameless"`
+	ChannelsRequest      []string        `yaml:"channels"`
+	Channels             []twitchChannel `yaml:"-"`
+	CollapseAfter        int             `yaml:"collapse-after"`
+	SortBy               string          `yaml:"sort-by"`
+	LinkCategoryToStream bool            `yaml:"link-category-to-stream"`
 }
 
 func (widget *twitchChannelsWidget) initialize() error {

--- a/internal/dynacat/widget-twitch-channels_test.go
+++ b/internal/dynacat/widget-twitch-channels_test.go
@@ -3,6 +3,7 @@ package dynacat
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
@@ -153,6 +154,48 @@ func TestCollectTwitchChannelBatchResultsPreservesPartialBatchResults(t *testing
 	}
 	if channels[0].Login != "one" || channels[1].Login != "three" || channels[2].Login != "four" {
 		t.Fatalf("Expected successful channels from both batches, got %#v", channels)
+	}
+}
+
+func TestTwitchChannelsWidgetCanLinkCategoryToStream(t *testing.T) {
+	widget := twitchChannelsWidget{
+		widgetBase: widgetBase{ContentAvailable: true},
+		Channels: []twitchChannel{{
+			Login:        "example",
+			Exists:       true,
+			Name:         "Example",
+			IsLive:       true,
+			Category:     "Science & Technology",
+			CategorySlug: "science-and-technology",
+		}},
+		LinkCategoryToStream: true,
+	}
+
+	html := string(widget.Render())
+	if !strings.Contains(html, `href="https://twitch.tv/example"`) {
+		t.Fatalf("Expected game name to link to stream, got %s", html)
+	}
+	if strings.Contains(html, `href="https://www.twitch.tv/directory/category/science-and-technology"`) {
+		t.Fatalf("Expected game category link to be absent, got %s", html)
+	}
+}
+
+func TestTwitchChannelsWidgetGameNameLinksToCategoryByDefault(t *testing.T) {
+	widget := twitchChannelsWidget{
+		widgetBase: widgetBase{ContentAvailable: true},
+		Channels: []twitchChannel{{
+			Login:        "example",
+			Exists:       true,
+			Name:         "Example",
+			IsLive:       true,
+			Category:     "Science & Technology",
+			CategorySlug: "science-and-technology",
+		}},
+	}
+
+	html := string(widget.Render())
+	if !strings.Contains(html, `href="https://www.twitch.tv/directory/category/science-and-technology"`) {
+		t.Fatalf("Expected game name to link to category, got %s", html)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `link-category-to-stream` to the Twitch channels widget.

When enabled, clicking the live stream category/game name opens the streamer’s channel instead of the Twitch category page.

## Why

The category name sits close to the streamer link, so it is easy to click it by mistake and end up on the game directory. For people who use this widget to follow streamers rather than browse games (me), opening the streamer is the more useful action.

Default behavior is unchanged.

P.S. it really annoys me, I've already misclicked like dozen of times