### PR TITLE
Support DOCKER_HOST for docker widgets

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -1418,7 +1418,7 @@ Display the status of your Docker containers along with an icon and an optional 
 
 > [!NOTE]
 >
-> The widget requires access to `docker.sock`. If you're running Dynacat inside a container, this can be done by mounting the socket as a volume:
+> The widget requires access to the Docker API. If you're running Dynacat inside a container, this can be done by mounting the socket as a volume or by setting `DOCKER_HOST` to a TCP Docker endpoint:
 >
 > ```yaml
 > services:
@@ -1505,7 +1505,7 @@ If any of the child containers are down, their status will propagate up to the p
 | ---- | ---- | -------- | ------- |
 | hide-by-default | boolean | no | false |
 | format-container-names | boolean | no | false |
-| sock-path | string | no | /var/run/docker.sock |
+| sock-path | string | no | `DOCKER_HOST`, otherwise `/var/run/docker.sock` |
 | category | string | no | |
 | running-only | boolean | no | false |
 | update-interval | string | no | 2m |
@@ -1517,7 +1517,7 @@ Whether to hide the containers by default. If set to `true` you'll have to manua
 When set to `true`, automatically converts container names such as `container_name_1` into `Container Name 1`.
 
 ##### `sock-path`
-The path to the Docker socket. This can also be a [remote socket](https://docs.docker.com/engine/daemon/remote-access/) or proxied socket using something like [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy).
+The path to the Docker socket. If not set, Dynacat will use `DOCKER_HOST` and then fall back to `/var/run/docker.sock`. This can also be a [remote socket](https://docs.docker.com/engine/daemon/remote-access/) or proxied socket using something like [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy).
 
 ###### `category`
 Filter to only the containers which have this category specified via the `dynacat.category` label. Useful if you want to have multiple containers widgets, each showing a different set of containers.
@@ -1599,7 +1599,7 @@ Example:
 
 > [!NOTE]
 >
-> The widget requires access to `docker.sock`. If you're running Dynacat inside a container, this can be done by mounting the socket as a volume:
+> The widget requires access to the Docker API. If you're running Dynacat inside a container, this can be done by mounting the socket as a volume or by setting `DOCKER_HOST` to a TCP Docker endpoint:
 >
 > ```yaml
 > services:
@@ -1618,7 +1618,7 @@ Preview:
 | Name | Type | Required | Default |
 | ---- | ---- | -------- | ------- |
 | show | string | no | both |
-| sock-path | string | no | /var/run/docker.sock |
+| sock-path | string | no | `DOCKER_HOST`, otherwise `/var/run/docker.sock` |
 | format-container-names | boolean | no | false |
 | collapse-after | integer | no | 4 |
 | update-interval | string | no | 15s |
@@ -1630,7 +1630,7 @@ Controls what to display in the widget. Possible values are:
 - `both` - Display both containers and images (default)
 
 ##### `sock-path`
-The path to the Docker socket. This can also be a [remote socket](https://docs.docker.com/engine/daemon/remote-access/) or proxied socket using something like [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy).
+The path to the Docker socket. If not set, Dynacat will use `DOCKER_HOST` and then fall back to `/var/run/docker.sock`. This can also be a [remote socket](https://docs.docker.com/engine/daemon/remote-access/) or proxied socket using something like [docker-socket-proxy](https://github.com/Tecnativa/docker-socket-proxy).
 
 ##### `format-container-names`
 When set to `true`, automatically converts container names such as `container_name_1` into `Container Name 1`.

--- a/internal/dynacat/widget-docker-containers.go
+++ b/internal/dynacat/widget-docker-containers.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -41,7 +42,10 @@ func (widget *dockerContainersWidget) initialize() error {
 	}
 
 	if widget.SockPath == "" {
-		widget.SockPath = "/var/run/docker.sock"
+		widget.SockPath = os.Getenv("DOCKER_HOST")
+		if widget.SockPath == "" {
+			widget.SockPath = "/var/run/docker.sock"
+		}
 	}
 
 	return nil

--- a/internal/dynacat/widget-docker-controller.go
+++ b/internal/dynacat/widget-docker-controller.go
@@ -109,7 +109,10 @@ func (widget *dockerControllerWidget) initialize() error {
 	widget.withTitle("Docker").withCacheDuration(15 * time.Second)
 
 	if widget.SockPath == "" {
-		widget.SockPath = "/var/run/docker.sock"
+		widget.SockPath = os.Getenv("DOCKER_HOST")
+		if widget.SockPath == "" {
+			widget.SockPath = "/var/run/docker.sock"
+		}
 	}
 
 	if widget.Show == "" {
@@ -150,11 +153,41 @@ func getSelfContainerID() string {
 	return string(m[:12])
 }
 
-func newDockerCtrlClient(sockPath string) *http.Client {
+type dockerCtrlHostTransport struct {
+	target *url.URL
+	base   http.RoundTripper
+}
+
+func (t *dockerCtrlHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.URL.Scheme = t.target.Scheme
+	cloned.URL.Host = t.target.Host
+	cloned.Host = t.target.Host
+	return t.base.RoundTrip(cloned)
+}
+
+func newDockerCtrlClient(source string) *http.Client {
+	if strings.HasPrefix(source, "tcp://") || strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		parsed, err := url.Parse(source)
+		if err == nil && parsed.Host != "" {
+			scheme := parsed.Scheme
+			if scheme == "tcp" {
+				scheme = "http"
+			}
+
+			return &http.Client{
+				Transport: &dockerCtrlHostTransport{
+					target: &url.URL{Scheme: scheme, Host: parsed.Host},
+					base:   http.DefaultTransport,
+				},
+			}
+		}
+	}
+
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-				return net.Dial("unix", sockPath)
+				return net.Dial("unix", source)
 			},
 		},
 	}


### PR DESCRIPTION
Makes the docker widgets use DOCKER_HOST when sock-path is not set, falling back to /var/run/docker.sock as before.

It also allows docker-controller to work with TCP/HTTP docker endpoints instead of requiring a socket, most likely useful to people who don't want to give containers socket access so expose a it via a proxy instead.