### PR TITLE
feat(auth): auto-redirect to OIDC flow when password auth is disabled

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -120,6 +120,12 @@ auth:
     redirect-url: https://dashboard.example.com/api/oidc/callback
 ```
 
+When password auth is disabled, an unauthenticated visit to a protected route
+is redirected **straight to the OIDC flow** (`/api/oidc/login`) instead of the
+`/login` interstitial — since the login page has no password form to offer,
+the only path forward is the identity provider. The user is returned to the
+page they originally requested after the OIDC callback completes.
+
 ### Provider guides
 
 #### Generic OIDC

--- a/internal/dynacat/auth.go
+++ b/internal/dynacat/auth.go
@@ -396,7 +396,7 @@ func (a *application) handleUnauthorizedResponse(w http.ResponseWriter, r *http.
 
 	switch fallback {
 	case redirectToLogin:
-		http.Redirect(w, r, a.Config.Server.BaseURL+"/login", http.StatusSeeOther)
+		http.Redirect(w, r, a.loginDestination(), http.StatusSeeOther)
 	case showUnauthorizedJSON:
 		w.WriteHeader(http.StatusUnauthorized)
 		w.Write([]byte(`{"error": "Unauthorized"}`))
@@ -416,9 +416,29 @@ func isSafeLocalPath(target string) bool {
 		!strings.HasPrefix(target, "/\\")
 }
 
+// oidcOnlyAuth reports whether the deployment authenticates exclusively via
+// OIDC. Config validation guarantees disable-password:true implies OIDC is
+// configured (config.go), so this is the "password login is unavailable" state.
+func (a *application) oidcOnlyAuth() bool {
+	return a.OIDCEnabled && !a.PasswordEnabled
+}
+
+// loginDestination returns where an unauthenticated visitor should be sent to
+// authenticate. When password auth is unavailable (disable-password + OIDC),
+// there is no point landing on the /login interstitial — the only way forward
+// is the OIDC flow, so send them straight to it. Otherwise keep the existing
+// /login page (which offers both password and OIDC entry points).
+func (a *application) loginDestination() string {
+	if a.oidcOnlyAuth() {
+		return a.Config.Server.BaseURL + "/api/oidc/login"
+	}
+	return a.Config.Server.BaseURL + "/login"
+}
+
 // redirectToLoginPage remembers where an unauthenticated visitor was headed
 // (path and query) so they can be returned there after logging in, then sends
-// them to the login page.
+// them to authenticate (the OIDC flow directly when it is the only auth
+// option, otherwise the login page).
 func (a *application) redirectToLoginPage(w http.ResponseWriter, r *http.Request) {
 	if target := r.URL.RequestURI(); isSafeLocalPath(target) {
 		http.SetCookie(w, &http.Cookie{
@@ -431,7 +451,7 @@ func (a *application) redirectToLoginPage(w http.ResponseWriter, r *http.Request
 			HttpOnly: true,
 		})
 	}
-	http.Redirect(w, r, a.Config.Server.BaseURL+"/login", http.StatusSeeOther)
+	http.Redirect(w, r, a.loginDestination(), http.StatusSeeOther)
 }
 
 // takeLoginRedirect consumes and clears the post-login redirect cookie,

--- a/internal/dynacat/auth_redirect_test.go
+++ b/internal/dynacat/auth_redirect_test.go
@@ -71,3 +71,69 @@ func TestLoginRedirectRoundTrip(t *testing.T) {
 		t.Errorf("takeLoginRedirect with off-origin value = %q, want /", got)
 	}
 }
+
+func TestLoginDestination(t *testing.T) {
+	cases := []struct {
+		name            string
+		oidcEnabled     bool
+		passwordEnabled bool
+		want            string
+	}{
+		{"password only", false, true, "/login"},
+		{"password + oidc", true, true, "/login"},
+		{"oidc only", true, false, "/api/oidc/login"},
+		{"no auth", false, false, "/login"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &application{OIDCEnabled: tc.oidcEnabled, PasswordEnabled: tc.passwordEnabled}
+			if got := app.loginDestination(); got != tc.want {
+				t.Errorf("loginDestination() = %q, want %q", got, tc.want)
+			}
+			if got := app.oidcOnlyAuth(); got != tc.oidcEnabled && tc.passwordEnabled == false && tc.oidcEnabled {
+				t.Errorf("oidcOnlyAuth() = %v, want true", got)
+			}
+		})
+	}
+}
+
+func TestRedirectToLoginPageDestination(t *testing.T) {
+	cases := []struct {
+		name            string
+		oidcEnabled     bool
+		passwordEnabled bool
+		want            string
+	}{
+		{"password + oidc goes to login page", true, true, "/login"},
+		{"oidc only skips interstitial", true, false, "/api/oidc/login"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &application{OIDCEnabled: tc.oidcEnabled, PasswordEnabled: tc.passwordEnabled}
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/secret?x=1", nil)
+			app.redirectToLoginPage(rec, req)
+			if loc := rec.Result().Header.Get("Location"); loc != tc.want {
+				t.Errorf("Location = %q, want %q", loc, tc.want)
+			}
+			// The redirect cookie must still be set so the user returns to the
+			// original page after the OIDC flow completes.
+			saved := findCookie(rec.Result().Cookies(), AUTH_REDIRECT_COOKIE_NAME)
+			if saved == nil || saved.Value != "/secret?x=1" {
+				t.Errorf("redirect cookie = %v, want value /secret?x=1", saved)
+			}
+		})
+	}
+}
+
+func TestHandleUnauthorizedResponseDestination(t *testing.T) {
+	app := &application{RequiresAuth: true, OIDCEnabled: true, PasswordEnabled: false}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if !app.handleUnauthorizedResponse(rec, req, redirectToLogin) {
+		t.Fatal("expected handleUnauthorizedResponse to report unauthorized")
+	}
+	if loc := rec.Result().Header.Get("Location"); loc != "/api/oidc/login" {
+		t.Errorf("Location = %q, want /api/oidc/login", loc)
+	}
+}


### PR DESCRIPTION
## What

When auth is configured with `disable-password: true` and only OIDC is enabled, an unauthenticated visit to a protected route now redirects straight to `/api/oidc/login` instead of landing on the `/login` interstitial.

With no password form on the login page, the interstitial is a dead end — the only path forward is the identity provider, so the redirect skips it.

## Why

An OIDC-only deployment currently bounces unauthenticated users to a login page that offers only an OIDC button, requiring an extra click before the flow begins. Auto-redirecting removes that friction.

## How

- Adds `oidcOnlyAuth()` (true when `OIDCEnabled && !PasswordEnabled`) and `loginDestination()` (returns `/api/oidc/login` for OIDC-only deployments, `/login` otherwise).
- Both redirect-to-login paths — `handleUnauthorizedResponse` and `redirectToLoginPage` — now use `loginDestination()`.
- The existing post-login redirect cookie is still set, so after the OIDC callback the user returns to the page they originally requested (round-trips via `takeLoginRedirect`).
- Config validation already guarantees `disable-password: true` implies OIDC is configured, so this state is well-defined.

## Tests

`auth_redirect_test.go` covers `loginDestination()` across all four auth modes (password-only / password+OIDC / OIDC-only / none) and asserts both redirect helpers send OIDC-only users to `/api/oidc/login` while preserving the redirect cookie. `gofmt`, `go vet`, and the full `go test ./...` suite pass.